### PR TITLE
SH code reorganization

### DIFF
--- a/specula/__init__.py
+++ b/specula/__init__.py
@@ -97,6 +97,19 @@ def cpuArray(v):
         return np.array(v)
 
 
+class DummyDecoratorAndContextManager():
+    def __init__(self):
+        pass
+    def __enter__(self):
+        pass
+    def __exit__(self, *args):
+        pass
+    def __call__(self, f):
+        def caller(*args, **kwargs):
+            return f(*args, **kwargs)
+        return caller
+
+
 def show_in_profiler(message=None, color_id=None, argb_color=None, sync=False):
     '''
     Decorator to allow using cupy's TimeRangeDecorator
@@ -112,18 +125,7 @@ def show_in_profiler(message=None, color_id=None, argb_color=None, sync=False):
                           sync=sync)
 
     except ImportError:
-        class DummyDecorator():
-            def __init__(self):
-                pass
-            def __enter__(self):
-                pass
-            def __exit__(self, *args):
-                pass
-            def __call__(self, f):
-                def caller(*args, **kwargs):
-                    return f(*args, **kwargs)
-                return caller
-        return DummyDecorator()
+        return DummyDecoratorAndContextManager()
 
 
 def fuse(kernel_name=None):

--- a/specula/base_data_obj.py
+++ b/specula/base_data_obj.py
@@ -73,12 +73,12 @@ class BaseDataObj(BaseTimeObj):
                 elif self.target_device_idx==-1:
                     if aType==np.ndarray:
                         #print(f'transferDataTo: {attr} to GPU')
-                        setattr(destobj, attr, cp.asarray( concrete_attr ) )                            
+                        setattr(destobj, attr, cp.asarray( concrete_attr ) )
+        destobj.generation_time = self.generation_time
         return destobj
 
 
     def copyTo(self, target_device_idx):
-        cloned = self
         excluded = ['_tag']
         if target_device_idx==self.target_device_idx:
             return self

--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -106,7 +106,7 @@ class BaseProcessingObj(BaseTimeObj):
 
     def trigger_code(self):
         '''
-        Any code implemented by derived classed must:
+        Any code implemented by derived classes must:
         1) only perform GPU operations using the xp module
            on arrays allocated with self.xp
         2) avoid any explicity numpy or normal python operation.

--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -119,6 +119,7 @@ class BaseProcessingObj(BaseTimeObj):
 
     def post_trigger(self):
         if self.target_device_idx>=0 and self.cuda_graph:
+            self._target_device.use()
             self.stream.synchronize()
 
 #        if self.checkInputTimes():
@@ -194,6 +195,8 @@ class BaseProcessingObj(BaseTimeObj):
         """
         self._loop_dt = loop_dt
         self._loop_niters = loop_niters
+        if self.target_device_idx >= 0:
+            self._target_device.use()
         for name, input in self.inputs.items():
             if input.get(self.target_device_idx) is None and not input.optional:
                 raise ValueError(f'Input {name} for object {self} has not been set')

--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -164,6 +164,7 @@ class BaseProcessingObj(BaseTimeObj):
                 self._target_device.use()
             if self.target_device_idx>=0 and self.cuda_graph:
                 self.cuda_graph.launch(stream=self.stream)
+                self.stream.synchronize()
             else:
                 self.trigger_code()
             self.ready = False

--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -1,7 +1,7 @@
 from astropy.io import fits
 
 from specula.base_time_obj import BaseTimeObj
-from specula import default_target_device, cp
+from specula import default_target_device, cp, DummyDecoratorAndContextManager
 from specula.connections import InputValue, InputList
 from contextlib import nullcontext
 
@@ -16,19 +16,26 @@ class BaseProcessingObj(BaseTimeObj):
         """
         BaseTimeObj.__init__(self, target_device_idx=target_device_idx, precision=precision)
 
-        if self.target_device_idx>=0:
+        if self.target_device_idx >= 0:
             from cupyx.scipy.ndimage import rotate
             from cupyx.scipy.interpolate import RegularGridInterpolator
+            from cupyx.scipy.fft import fft2 as scipy_fft2
+            from cupyx.scipy.fft import ifft2 as scipy_ifft2
             from cupyx.scipy.fft import get_fft_plan
             self._target_device.use()
         else:
             from scipy.ndimage import rotate
             from scipy.interpolate import RegularGridInterpolator
-            get_fft_plan = None
+            from scipy.fft import fft2 as scipy_fft2
+            from scipy.fft import ifft2 as scipy_ifft2
+            def get_fft_plan(*args, **kwargs):
+                return DummyDecoratorAndContextManager()
 
         self.rotate = rotate        
         self.RegularGridInterpolator = RegularGridInterpolator
         self._get_fft_plan = get_fft_plan
+        self._scipy_fft2 = scipy_fft2
+        self._scipy_ifft2 = scipy_ifft2
 
         self.current_time = 0
         self.current_time_seconds = 0

--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -132,6 +132,9 @@ class BaseProcessingObj(BaseTimeObj):
 
     def capture_stream(self):
         with self.stream:
+            # First execution is needed to build the FFT plan cache
+            # See for example https://github.com/cupy/cupy/issues/7559
+            self.trigger_code()
             self.stream.begin_capture()
             self.trigger_code()
             self.cuda_graph = self.stream.end_capture()

--- a/specula/data_objects/electric_field.py
+++ b/specula/data_objects/electric_field.py
@@ -40,9 +40,11 @@ class ElectricField(BaseDataObj):
     def phi_at_lambda(self, wavelengthInNm):
         return self.phaseInNm * ((2 * self.xp.pi) / wavelengthInNm)
 
-    def ef_at_lambda(self, wavelengthInNm):
+    def ef_at_lambda(self, wavelengthInNm, out=None):
         phi = self.phi_at_lambda(wavelengthInNm)
-        return self.A * self.xp.exp(1j * phi, dtype=self.complex_dtype)
+        ef = self.xp.exp(1j * phi, dtype=self.complex_dtype, out=out)
+        ef *= self.A
+        return ef
 
     def product(self, ef2, subrect=None):
 #        subrect = self.checkOther(ef2, subrect=subrect)    # TODO check subrect from atmo_propagation, even in PASSATA it does not seem right

--- a/specula/data_objects/electric_field.py
+++ b/specula/data_objects/electric_field.py
@@ -15,12 +15,23 @@ class ElectricField(BaseDataObj):
         self.phaseInNm = self.xp.zeros((dimx, dimy), dtype=self.dtype)
 
     def set_value(self, v):
-        self.A = v[0]
-        self.phaseInNm = v[1]
+        '''
+        Set new values for phase and amplitude
+        
+        Arrays are not reallocated
+        '''
+        self.A[:]= self.xp.array(v[0], dtype=self.dtype)
+        self.phaseInNm[:] = self.xp.array(v[1], dtype=self.dtype)
 
     def reset(self):
-        self.A = self.xp.ones_like(self.A)
-        self.phaseInNm = self.xp.zeros_like(self.phaseInNm)
+        '''
+        Reset to zero phase and unitary amplitude
+        
+        Arrays are not reallocated
+        '''
+        self.A *= 0
+        self.A += 1
+        self.phaseInNm *= 0
 
     @property
     def size(self):

--- a/specula/lib/extrapolate_edge_pixel.py
+++ b/specula/lib/extrapolate_edge_pixel.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 
-def extrapolate_edge_pixel(phase, sum_1pix_extra, sum_2pix_extra, out=None, xp=np):
+def extrapolate_edge_pixel(phase, sum_1pix_extra, sum_2pix_extra, idx_1pix, idxExtraPol2, out=None, xp=np):
     """
     Extrapolates the phase array at the edges based on neighboring pixel values.
 
@@ -15,16 +15,10 @@ def extrapolate_edge_pixel(phase, sum_1pix_extra, sum_2pix_extra, out=None, xp=n
     if out is None:
         out = phase.copy()
     
-    # Find indices where extrapolation is needed (for 1-pixel extrapolation)
-    idx_1pix = xp.where(sum_1pix_extra >= 0)
-    
     # Extract extrapolated values from the phase array using indices
     # Use ravel() instead of .flat for cupy compatibility
     vectExtraPol = phase.ravel()[sum_1pix_extra[idx_1pix]]
     vectExtraPol2 = phase.ravel()[sum_2pix_extra[idx_1pix]]
-    
-    # Find indices for 2-pixel extrapolation where value is defined
-    idxExtraPol2 = xp.where(sum_2pix_extra[idx_1pix] >= 0)
     
     # Update vectExtraPol based on 2-pixel extrapolation conditions
     vectExtraPol[idxExtraPol2] = 2 * vectExtraPol[idxExtraPol2] - vectExtraPol2[idxExtraPol2]

--- a/specula/lib/extrapolate_edge_pixel_mat_define.py
+++ b/specula/lib/extrapolate_edge_pixel_mat_define.py
@@ -129,6 +129,15 @@ def extrapolate_edge_pixel_mat_define(mask, do_ext_2_pix=False):
                 if sum_1pix_extra[idx] == -1 and test >= 0:
                     sum_1pix_extra[idx] = test
 
-    return sum_1pix_extra.astype(np.int32), sum_2pix_extra.astype(np.int32)
+    # Find indices where extrapolation is needed (for 1-pixel extrapolation)
+    # Find indices for 2-pixel extrapolation where value is defined
+    idx_1pix = np.where(sum_1pix_extra >= 0)
+    idxExtraPol2 = np.where(sum_2pix_extra[idx_1pix] >= 0)
+
+    return (sum_1pix_extra.astype(np.int32),
+           sum_2pix_extra.astype(np.int32),
+           idx_1pix,
+           idxExtraPol2)
+           
 
 

--- a/specula/lib/utils.py
+++ b/specula/lib/utils.py
@@ -33,3 +33,17 @@ def get_type_hints(type):
     for x in type.__mro__:
         hints.update(typing.get_type_hints(getattr(x, '__init__')))
     return hints
+
+def unravel_index_2d(idxs, shape, xp):
+    '''Unravel linear indexes in a 2d-shape (in row-major C order)
+    
+    Replaces cupy.unravel_index, that forces 2 separate DtH transfers
+    '''
+    if len(shape) != 2:
+        raise ValueError('shape must be 2d')
+    
+    idxs = xp.array(idxs).astype(int)
+    _, ncols = shape
+    row_idx = idxs // ncols
+    col_idx = idxs - (row_idx * ncols)
+    return row_idx, col_idx

--- a/specula/processing_objects/modulated_pyramid.py
+++ b/specula/processing_objects/modulated_pyramid.py
@@ -393,7 +393,7 @@ class ModulatedPyramid(BaseProcessingObj):
         #                        self.xp.rebin(self.in_ef.phi_at_lambda(self.wavelength_in_nm), (self.ef_size[0] * self.fov_res, self.ef_size[1] * self.fov_res)) * 1j)
         #else:
 
-        self.ef[:] = self.in_ef.ef_at_lambda(self.wavelength_in_nm)
+        self.in_ef.ef_at_lambda(self.wavelength_in_nm, out=self.ef)
 
     @show_in_profiler('pyramid.trigger_code')
     def trigger_code(self):

--- a/specula/processing_objects/sh.py
+++ b/specula/processing_objects/sh.py
@@ -220,10 +220,8 @@ class SH(BaseProcessingObj):
         elif not self._noprints:
             print(f'GOOD: interpolated input phase size {ef_size} * {round(self._fov_ovs)} is divisible by {self._lenslet.n_lenses} subapertures.')
     
-    def calc_trigger_geometry(self):
+    def calc_trigger_geometry(self, in_ef):
         
-        in_ef = self.inputs['in_ef'].get(target_device_idx=self.target_device_idx)
-
         subap_wanted_fov = self._subap_wanted_fov
         sensor_pxscale = self._sensor_pxscale
         subap_npx = self._subap_npx
@@ -364,7 +362,7 @@ class SH(BaseProcessingObj):
 
         with show_in_profiler('toccd'):
             self._out_i.i[:] = toccd(self._psfimage, (self._ccd_side, self._ccd_side), xp=self.xp)
-        
+
     def post_trigger(self):
         super().post_trigger()
 
@@ -379,7 +377,7 @@ class SH(BaseProcessingObj):
         in_ef = self.inputs['in_ef'].get(target_device_idx=self.target_device_idx)
 
         self.set_in_ef(in_ef)
-        self.calc_trigger_geometry()
+        self.calc_trigger_geometry(in_ef)
 
         fov_oversample = self._fov_ovs
         shape_ovs = (int(in_ef.size[0] * fov_oversample), int(in_ef.size[1] * fov_oversample))

--- a/specula/processing_objects/sh.py
+++ b/specula/processing_objects/sh.py
@@ -400,7 +400,7 @@ class SH(BaseProcessingObj):
         self.plan_wf3 = self._get_fft_plan(self._wf3, axes=(1, 2), value_type='C2C')
         self.plan_psf_shifted = self._get_fft_plan(self.psf_shifted, axes=(1, 2))
 
-#        super().build_stream()
+        super().build_stream(allow_parallel=False)
 
     def get_tlt_f(self, p, c):
         iu = complex(0, 1)

--- a/specula/processing_objects/sh_slopec.py
+++ b/specula/processing_objects/sh_slopec.py
@@ -2,7 +2,8 @@
 import numpy as np
 
 from specula import fuse
-from specula.lib import make_mask
+from specula.lib.make_mask import make_mask
+from specula.lib.utils import unravel_index_2d
 from specula.data_objects.slopes import Slopes
 from specula.data_objects.subap_data import SubapData
 from specula.base_value import BaseValue
@@ -55,7 +56,6 @@ class ShSlopec(Slopec):
         self.cog_2ndstep_size = 0
         self.dotemplate = False
         self.store_thr_mask_cube = False
-        self._idx2d = None
 
         self.exp_weight = exp_weight
         self.subapdata = subapdata
@@ -301,16 +301,6 @@ class ShSlopec(Slopec):
         if self.verbose:
             print(f"Slopes min, max and rms : {self.xp.min(sx)}, {self.xp.max(sx)}, {self.xp.sqrt(self.xp.mean(sx ** 2))}")
 
-    def idx2(self, subap_idx, orig_pixels_shape):
-        '''
-        Return the 2d index from the ravel-ed subap_idx one
-        
-        Result is cached because apparently cupy's unravel_index() is really slow
-        '''
-        if self._idx2d is None:
-            self._idx2d = self.xp.unravel_index(subap_idx, orig_pixels_shape)
-        return self._idx2d
-    
     def calc_slopes_nofor(self, accumulated=False):
         """
         Calculate slopes without a for-loop over subapertures.
@@ -333,7 +323,7 @@ class ShSlopec(Slopec):
             raise ValueError("Only one between _thr_value and _thr_ratio_value can be set.")
 
         # Reform pixels based on the subaperture index
-        idx2d = self.idx2(self.subap_idx, orig_pixels.shape)
+        idx2d = unravel_index_2d(self.subap_idx, orig_pixels.shape, self.xp)
         pixels = orig_pixels[idx2d].T
         
         if self.weight_from_accumulated:

--- a/specula/processing_objects/sh_slopec.py
+++ b/specula/processing_objects/sh_slopec.py
@@ -55,6 +55,7 @@ class ShSlopec(Slopec):
         self.cog_2ndstep_size = 0
         self.dotemplate = False
         self.store_thr_mask_cube = False
+        self._idx2d = None
 
         self.exp_weight = exp_weight
         self.subapdata = subapdata
@@ -300,6 +301,15 @@ class ShSlopec(Slopec):
         if self.verbose:
             print(f"Slopes min, max and rms : {self.xp.min(sx)}, {self.xp.max(sx)}, {self.xp.sqrt(self.xp.mean(sx ** 2))}")
 
+    def idx2(self, subap_idx, orig_pixels_shape):
+        '''
+        Return the 2d index from the ravel-ed subap_idx one
+        
+        Result is cached because apparently cupy's unravel_index() is really slow
+        '''
+        if self._idx2d is None:
+            self._idx2d = self.xp.unravel_index(subap_idx, orig_pixels_shape)
+        return self._idx2d
     
     def calc_slopes_nofor(self, accumulated=False):
         """
@@ -323,7 +333,7 @@ class ShSlopec(Slopec):
             raise ValueError("Only one between _thr_value and _thr_ratio_value can be set.")
 
         # Reform pixels based on the subaperture index
-        idx2d = self.xp.unravel_index(self.subap_idx, orig_pixels.shape)
+        idx2d = self.idx2(self.subap_idx, orig_pixels.shape)
         pixels = orig_pixels[idx2d].T
         
         if self.weight_from_accumulated:

--- a/test/test_electric_field.py
+++ b/test/test_electric_field.py
@@ -1,0 +1,47 @@
+
+
+import specula
+specula.init(0)  # Default target device
+
+import unittest
+
+from specula import np
+from specula import cpuArray
+
+from specula.data_objects.electric_field import ElectricField
+
+from test.specula_testlib import cpu_and_gpu
+
+class TestElectricField(unittest.TestCase):
+   
+    @cpu_and_gpu
+    def test_reset_does_not_reallocate(self, target_device_idx, xp):
+        
+        ef = ElectricField(10,10, 0.1, S0=1, target_device_idx=target_device_idx)
+        
+        id_A_before = id(ef.A)
+        id_p_before = id(ef.phaseInNm)
+        
+        ef.reset()
+        
+        id_A_after = id(ef.A)
+        id_p_after = id(ef.phaseInNm)
+        
+        assert id_A_before == id_A_after
+        assert id_p_before == id_p_after
+
+    @cpu_and_gpu
+    def test_set_value_does_not_reallocate(self, target_device_idx, xp):
+        
+        ef = ElectricField(10,10, 0.1, S0=1, target_device_idx=target_device_idx)
+        
+        id_A_before = id(ef.A)
+        id_p_before = id(ef.phaseInNm)
+        
+        ef.set_value([xp.ones(100).reshape(10,10), xp.zeros(100).reshape(10,10)])
+        
+        id_A_after = id(ef.A)
+        id_p_after = id(ef.phaseInNm)
+        
+        assert id_A_before == id_A_after
+        assert id_p_before == id_p_after

--- a/test/test_extrapol_mat_define.py
+++ b/test/test_extrapol_mat_define.py
@@ -19,7 +19,7 @@ class TestExtrapolMatDefine(unittest.TestCase):
         
         datadir = os.path.join(os.path.dirname(__file__), 'data')
         mask = fits.getdata(os.path.join(datadir, 'mask.fits'))
-        mat1, mat2 = extrapolate_edge_pixel_mat_define(mask, do_ext_2_pix=False)
+        mat1, mat2, id1pix, idx2pix = extrapolate_edge_pixel_mat_define(mask, do_ext_2_pix=False)
         ref1 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixFalse.fits'), ext=0)
         ref2 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixFalse.fits'), ext=1)
         
@@ -30,7 +30,7 @@ class TestExtrapolMatDefine(unittest.TestCase):
         
         datadir = os.path.join(os.path.dirname(__file__), 'data')
         mask = fits.getdata(os.path.join(datadir, 'mask.fits'))
-        mat1, mat2 = extrapolate_edge_pixel_mat_define(mask, do_ext_2_pix=True)
+        mat1, mat2, id1pix, idx2pix = extrapolate_edge_pixel_mat_define(mask, do_ext_2_pix=True)
         ref1 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixTrue.fits'), ext=0)
         ref2 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixTrue.fits'), ext=1)
         

--- a/test/test_extrapolate_edge_pixel.py
+++ b/test/test_extrapolate_edge_pixel.py
@@ -24,7 +24,13 @@ class TestExtrapolateEdgePixel(unittest.TestCase):
         mat1 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixFalse.fits'), ext=0).astype(int)
         mat2 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixFalse.fits'), ext=1).astype(int)
         
-        test = extrapolate_edge_pixel(xp.array(phase), xp.array(mat1), xp.array(mat2), xp=xp)
+        idx_1pix = np.where(mat1 >= 0)
+        idx_2pix = np.where(mat2[idx_1pix] >= 0)
+    
+        xp_idx_1pix = tuple(map(xp.array, idx_1pix))
+        xp_idx_2pix = tuple(map(xp.array, idx_2pix))
+    
+        test = extrapolate_edge_pixel(xp.array(phase), xp.array(mat1), xp.array(mat2), xp_idx_1pix, xp_idx_2pix, xp=xp)
         np.testing.assert_array_almost_equal(cpuArray(test), ref)
 
     @cpu_and_gpu
@@ -35,7 +41,13 @@ class TestExtrapolateEdgePixel(unittest.TestCase):
         ref = fits.getdata(os.path.join(datadir, 'extrapolated2.fits'))
         mat1 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixTrue.fits'), ext=0).astype(int)
         mat2 = fits.getdata(os.path.join(datadir, 'extrapol_array_doExt2PixTrue.fits'), ext=1).astype(int)
+
+        idx_1pix = np.where(mat1 >= 0)
+        idx_2pix = np.where(mat2[idx_1pix] >= 0)
+    
+        xp_idx_1pix = tuple(map(xp.array, idx_1pix))
+        xp_idx_2pix = tuple(map(xp.array, idx_2pix))
         
-        test = extrapolate_edge_pixel(xp.array(phase), xp.array(mat1), xp.array(mat2), xp=xp)
+        test = extrapolate_edge_pixel(xp.array(phase), xp.array(mat1), xp.array(mat2), xp_idx_1pix, xp_idx_2pix, xp=xp)
         np.testing.assert_array_almost_equal(cpuArray(test), ref)
 

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -41,3 +41,58 @@ class TestSH(unittest.TestCase):
         
         np.testing.assert_almost_equal(xp.sum(intensity.i), ref_S0 * ef.masked_area())
 
+    @cpu_and_gpu
+    def test_pixelscale(self, target_device_idx, xp):
+        '''
+        Test that pixelscale is correctly handled, by comparing spots from a flat 
+        wavefront and from a tilted one. The introduced tilt corresponds to exactly 1 pixel,
+        and we verify that the resulting intensity field is indeed shifted by 1 pixel
+        in the correct direction
+        '''
+        t = 1
+        pxscale_arcsec = 0.5
+        pixel_pupil = 120
+        pixel_pitch = 0.05
+        sh_npix = 6
+
+        sh = SH(wavelengthInNm=500,
+                subap_wanted_fov= sh_npix * pxscale_arcsec,
+                sensor_pxscale=pxscale_arcsec,
+                subap_on_diameter=20,
+                subap_npx=sh_npix,
+                convolGaussSpotSize=1.0,
+                target_device_idx=target_device_idx)
+
+        # Flat wavefront
+        ef = ElectricField(pixel_pupil, pixel_pupil, pixel_pitch, S0=1, target_device_idx=target_device_idx)
+        ef.generation_time = t
+        sh.inputs['in_ef'].set(ef)
+
+        sh.check_ready(t)
+        sh.trigger()
+        sh.post_trigger()
+        flat = sh.outputs['out_i'].i.copy()
+        
+        # tilt corresponding to pxscale_arcsec
+        tilt_value = np.radians(pixel_pupil * pixel_pitch * 1/(60*60) * pxscale_arcsec)
+        tilt = np.linspace(-tilt_value / 2, tilt_value / 2, pixel_pupil)
+
+        # Tilted wavefront
+        ef.phaseInNm[:] = xp.array(np.broadcast_to(tilt, (pixel_pupil, pixel_pupil))) * 1e9
+        ef.generation_time = t+1
+
+        sh.check_ready(t+1)
+        sh.trigger()
+        sh.post_trigger()
+        tilted = sh.outputs['out_i'].i.copy()
+        
+        flat_shifted = np.roll(flat, (0, 1))
+
+        # Remove the left column edges on each subap (comparison is invalid after roll)
+        flat_shifted[:, ::sh_npix] = 0
+        tilted[:, ::sh_npix] = 0
+        
+        np.testing.assert_array_almost_equal(cpuArray(tilted), cpuArray(flat_shifted), decimal=3) 
+        
+
+ 

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -34,6 +34,7 @@ class TestSH(unittest.TestCase):
 
         sh.inputs['in_ef'].set(ef)
 
+        sh.setup(1, 1)
         sh.check_ready(t)
         sh.trigger()
         sh.post_trigger()
@@ -68,6 +69,7 @@ class TestSH(unittest.TestCase):
         ef.generation_time = t
         sh.inputs['in_ef'].set(ef)
 
+        sh.setup(1, 1)
         sh.check_ready(t)
         sh.trigger()
         sh.post_trigger()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,41 @@
+
+
+import specula
+specula.init(0)  # Default target device
+
+import unittest
+
+from specula import np
+from specula import cpuArray
+
+from specula.lib.utils import unravel_index_2d
+
+from test.specula_testlib import cpu_and_gpu
+
+class TestUtils(unittest.TestCase):
+   
+    @cpu_and_gpu
+    def test_unravel_index_square_shape(self, target_device_idx, xp):
+        
+        idxs = xp.array([1,2,3])
+        shape = (3,3)
+        y, x = unravel_index_2d(idxs, shape, xp) 
+        ytest, xtest = xp.unravel_index(idxs, shape)
+        np.testing.assert_array_almost_equal(cpuArray(x), cpuArray(xtest))
+        np.testing.assert_array_almost_equal(cpuArray(y), cpuArray(ytest))
+
+    @cpu_and_gpu
+    def test_unravel_index_rectangular_shape(self, target_device_idx, xp):
+       
+        idxs = xp.array([2,6,13])
+        shape = (4,8)
+        y, x = unravel_index_2d(idxs, shape, xp) 
+        ytest, xtest = xp.unravel_index(idxs, shape)
+        np.testing.assert_array_almost_equal(cpuArray(x), cpuArray(xtest))
+        np.testing.assert_array_almost_equal(cpuArray(y), cpuArray(ytest))
+
+    @cpu_and_gpu
+    def test_unravel_index_wrong_shape(self, target_device_idx, xp):
+
+        with self.assertRaises(ValueError):
+            _ = unravel_index_2d([1,2,3], (1,2,3), xp)


### PR DESCRIPTION
Reorganized SH code, adding streams.
Added per-GPU default stream, to parallelize over multiple GPUs while remaining serialized on each one.
Fixed some bugs in data object transfers between GPUs and in post_trigger()
Fixed bug in capturing FFT plans in streams
Fixed bug ElectricField.reset arrays, avoding a reallocation (important to avoid propagation bugs with streams)
Optimized ElectricField.ef_at_lambda, avoiding a reallocation if the out= argument is given.
SH code reuses some intermediate arrays between instances, saving about 4GB of GPU memory.
Added a few unit tests