### PR TITLE
Fixed input_ref and DisplayServer

### DIFF
--- a/specula/processing_objects/display_server.py
+++ b/specula/processing_objects/display_server.py
@@ -59,13 +59,13 @@ class DisplayServer(BaseProcessingObj):
         # Heuristic to detect inputs: they usually start with "in_"
         def data_obj_getter(name):
             if '.in_' in name:
-                return input_ref_getter(name, target_device_idx=-1)[0]
+                return input_ref_getter(name)
             else:
                 try:
-                    return output_ref_getter(name)[0]
+                    return output_ref_getter(name)
                 except ValueError:
                     # Try inputs as well
-                    return input_ref_getter(name, target_device_idx=-1)[0]
+                    return input_ref_getter(name)
 
         self.data_obj_getter = data_obj_getter
         self.info_getter = info_getter


### PR DESCRIPTION
Fixed issues with DisplayServer introduced with the last PR, because the interface with Simul.output_ref() has changed.

Also modified Simul.input_ref() to be a special case of output_ref(), since the logic is almost identical and it was only used by DisplayServer.