### PR TITLE
Times saved by data store must be integer

### DIFF
--- a/specula/processing_objects/data_store.py
+++ b/specula/processing_objects/data_store.py
@@ -65,7 +65,7 @@ class DataStore(BaseProcessingObj):
                 print("Warning: replay_params not available, skipping replay_params.yml creation")
 
     def save_fits(self, compress=False):
-        times = {k: np.array(list(v.keys()), dtype=self.dtype) for k, v in self.storage.items() if isinstance(v, OrderedDict)}
+        times = {k: np.array(list(v.keys()), dtype=np.uint64) for k, v in self.storage.items() if isinstance(v, OrderedDict)}
         data = {k: np.array(list(v.values()), dtype=self.dtype) for k, v in self.storage.items() if isinstance(v, OrderedDict)}
 
         for k,v in times.items():

--- a/test/test_data_store.py
+++ b/test/test_data_store.py
@@ -50,3 +50,6 @@ class TestDataStore(unittest.TestCase):
         gen_data = fits.getdata(gen_file)
         np.testing.assert_array_almost_equal(gen_data, np.array([[0], [0.9510565162951535]]))
 
+        # Make sure times are in int64
+        gen_times = fits.getdata(gen_file, ext=1)
+        assert gen_times.dtype == np.uint64


### PR DESCRIPTION
Fixes a bug where times are saved in floating point, and data replication by DataSource might have issues