### PR TITLE
Fixed toccd newshape bug

### DIFF
--- a/specula/lib/toccd.py
+++ b/specula/lib/toccd.py
@@ -9,7 +9,7 @@
 #########################################################
 
 
-from specula import cp
+from specula import cp, cpuArray
 from specula.lib.rebin import rebin2d
 
 
@@ -36,7 +36,26 @@ def toccd(a, newshape, set_total=None, xp=None):
     to rebin an array similar to openvc's INTER_AREA interpolation.
 
     If a GPU is available, calculation is delegated to toccd_gpu()
+
+    Parameters
+    ----------
+    a : array
+        array to be resized
+    newshape : tuple, list or array
+        shape of resized array
+    set total : float, optional
+        if set, normalize the resized array to this total count.
+        if not set, the same total count as the input array is used.
+    xp : module
+        numpy or cupy module
+
+    Returns
+    -------
+    array
+        resized array
     '''
+    newshape = tuple(cpuArray(newshape))  # Works for lists, tuples and any cupy/numpy array
+
     if a.shape == newshape:
         return a
 

--- a/test/test_toccd.py
+++ b/test/test_toccd.py
@@ -1,0 +1,24 @@
+import unittest
+import numpy as np
+
+import specula
+specula.init(0)  # Default target device
+
+from specula import cpuArray
+from specula.lib.toccd import toccd
+from test.specula_testlib import cpu_and_gpu
+
+class TestToccd(unittest.TestCase):
+
+    @cpu_and_gpu
+    def test_toccd_shape_inputs(self, target_device_idx, xp):
+        
+        a = xp.arange(9).reshape((3,3)).astype(xp.float32)
+
+        a1 = toccd(a, newshape=(2, 2), xp=xp)  # tuple
+        a2 = toccd(a, newshape=xp.array((2, 2)), xp=xp)   # numpy/cupy array
+        a3 = toccd(a, newshape=[2, 2], xp=xp)  # list
+
+        np.testing.assert_array_equal(cpuArray(a1), cpuArray(a2))
+        np.testing.assert_array_equal(cpuArray(a1), cpuArray(a3))
+


### PR DESCRIPTION
This PR fixes a bug reported by @Menessao, where setting the *newshape* parameter to an array would cause an exception.

With this patch, newshape can be a list, tuple, numpy or cupy array.