### PR TITLE
Fixed warning on seeing vector size, removed unused lines

### DIFF
--- a/specula/data_objects/pupilstop.py
+++ b/specula/data_objects/pupilstop.py
@@ -121,7 +121,7 @@ class Pupilstop(Layer):
     def restore_from_passata(filename, target_device_idx=None):
         with fits.open(filename) as hdul:
             if len(hdul) == 4:
-                pixel_pitch = float(hdul[3].data)
+                pixel_pitch = float(hdul[3].data[0])
                 A = hdul[1].data.copy()
                 pixel_pupil = A.shape[0]
                 simul_params = SimulParams(pixel_pupil, pixel_pitch)

--- a/specula/processing_objects/atmo_evolution.py
+++ b/specula/processing_objects/atmo_evolution.py
@@ -26,6 +26,7 @@ class AtmoEvolution(BaseProcessingObj):
                  fov: float=0.0,
                  pixel_phasescreens: int=8192,
                  seed: int=1,
+                 extra_delta_time: float=0,
                  verbose: bool=False,
                  fov_in_m: float=None,
                  pupil_position:list =[0,0],
@@ -45,6 +46,7 @@ class AtmoEvolution(BaseProcessingObj):
         self.last_t = 0
         self.cycle_screens = True
         self.delta_time = None
+        self.extra_delta_time = extra_delta_time  # TODO to be used for speed-of-light corrections
                 
         self.inputs['seeing'] = InputValue(type=BaseValue)
         self.inputs['wind_speed'] = InputValue(type=BaseValue)

--- a/specula/processing_objects/atmo_evolution.py
+++ b/specula/processing_objects/atmo_evolution.py
@@ -43,13 +43,8 @@ class AtmoEvolution(BaseProcessingObj):
         self.n_phasescreens = len(heights)
         self.last_position = np.zeros(self.n_phasescreens)
         self.last_t = 0
-        self.extra_delta_time = 0
         self.cycle_screens = True
-
-        self.delta_time = 1
-        self.seeing = 1
-        self.wind_speed = 1
-        self.wind_direction = 1        
+        self.delta_time = None
                 
         self.inputs['seeing'] = InputValue(type=BaseValue)
         self.inputs['wind_speed'] = InputValue(type=BaseValue)
@@ -91,9 +86,6 @@ class AtmoEvolution(BaseProcessingObj):
         self.Cn2 = np.array(Cn2, dtype=self.dtype)
         self.pixel_pupil = self.pixel_pupil
         self.data_dir = data_dir
-        self.seeing = None
-        self.wind_speed = None
-        self.wind_direction = None
 
         # TODO old code
         self.pixel_square_phasescreens = pixel_phasescreens
@@ -214,15 +206,28 @@ class AtmoEvolution(BaseProcessingObj):
 
         self.phasescreens_sizes_array = np.asarray(self.phasescreens_sizes)
     
+    def setup(self):
+        super().setup()
+    
+        # check that seeing is a 1-element array
+        if len(self.local_inputs['seeing'].value) != 1:
+            raise ValueError('Seeing input must be a 1-element array')
+        
+        # Check that wind speed and direction have the correct length
+        if len(self.local_inputs['wind_speed'].value) != self.n_phasescreens:
+            raise ValueError('Wind speed input must be a {self.n_phasescreens}-elements array')
+        if len(self.local_inputs['wind_direction'].value) != self.n_phasescreens:
+            raise ValueError('Wind direction input must be a {self.n_phasescreens}-elements array')
+        
     def prepare_trigger(self, t):
         super().prepare_trigger(t)
-        self.delta_time = self.t_to_seconds(self.current_time - self.last_t) + self.extra_delta_time        
-    
+        self.delta_time = self.t_to_seconds(self.current_time - self.last_t)
+            
     def trigger_code(self):
 
         # if len(self.phasescreens) != len(wind_speed) or len(self.phasescreens) != len(wind_direction):
         #     raise ValueError('Error: number of elements of wind speed and/or direction does not match the number of phasescreens')
-        seeing = float(cpuArray(self.local_inputs['seeing'].value))
+        seeing = float(cpuArray(self.local_inputs['seeing'].value[0]))
         wind_speed = cpuArray(self.local_inputs['wind_speed'].value)
         wind_direction = cpuArray(self.local_inputs['wind_direction'].value)
         r0 = 0.9759 * 0.5 / (seeing * 4.848) * self.airmass**(-3./5.) # if seeing > 0 else 0.0

--- a/specula/processing_objects/atmo_evolution.py
+++ b/specula/processing_objects/atmo_evolution.py
@@ -46,7 +46,7 @@ class AtmoEvolution(BaseProcessingObj):
         self.last_t = 0
         self.cycle_screens = True
         self.delta_time = None
-        self.extra_delta_time = extra_delta_time  # TODO to be used for speed-of-light corrections
+        self.extra_delta_time = extra_delta_time
                 
         self.inputs['seeing'] = InputValue(type=BaseValue)
         self.inputs['wind_speed'] = InputValue(type=BaseValue)
@@ -223,7 +223,7 @@ class AtmoEvolution(BaseProcessingObj):
         
     def prepare_trigger(self, t):
         super().prepare_trigger(t)
-        self.delta_time = self.t_to_seconds(self.current_time - self.last_t)
+        self.delta_time = self.t_to_seconds(self.current_time - self.last_t) + self.extra_delta_time
             
     def trigger_code(self):
 

--- a/specula/processing_objects/atmo_infinite_evolution.py
+++ b/specula/processing_objects/atmo_infinite_evolution.py
@@ -258,8 +258,6 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
         # fixed at generation time, then is a input -> rescales the screen?
         self.seeing = 0.8
         self.l0 = 0.005
-        self.wind_speed = 1
-        self.wind_direction = 1
         self.airmass = 1
         self.ref_wavelengthInNm = 500
 
@@ -297,9 +295,6 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
             raise ValueError(f"L0 must have the same length as heights ({len(self.heights)}), got {len(self.L0)}")
 
         self.Cn2 = np.array(Cn2, dtype=self.dtype)
-        self.wind_speed = None
-        self.wind_direction = None
-
         self.verbose = verbose if verbose is not None else False
 
         # Initialize layer list with correct heights
@@ -347,6 +342,17 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
                                                        precision=self.precision )
             self.infinite_phasescreens.append(temp_infinite_screen)
 
+    def setup(self):
+        super().setup()
+        # check that seeing is a 1-element array
+        if len(self.local_inputs['seeing'].value) != 1:
+            raise ValueError('Seeing input must be a 1-element array')
+        
+        # Check that wind speed and direction have the correct length
+        if len(self.local_inputs['wind_speed'].value) != self.n_infinite_phasescreens:
+            raise ValueError('Wind speed input must be a {self.n_infinite_phasescreens}-elements array')
+        if len(self.local_inputs['wind_direction'].value) != self.n_infinite_phasescreens:
+            raise ValueError('Wind direction input must be a {self.n_infinite_phasescreens}-elements array')
 
     def prepare_trigger(self, t):
         super().prepare_trigger(t)
@@ -354,7 +360,7 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
 
     @show_in_profiler('atmo_evolution.trigger_code')
     def trigger_code(self):
-        seeing = float(cpuArray(self.local_inputs['seeing'].value))
+        seeing = float(cpuArray(self.local_inputs['seeing'].value[0]))
         wind_speed = cpuArray(self.local_inputs['wind_speed'].value)
         wind_direction = cpuArray(self.local_inputs['wind_direction'].value)
 

--- a/specula/processing_objects/atmo_infinite_evolution.py
+++ b/specula/processing_objects/atmo_infinite_evolution.py
@@ -238,6 +238,7 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
                  zenithAngleInDeg: float=0.0,
                  fov: float=0.0,
                  seed: int=1,
+                 extra_delta_time: float=0,
                  verbose: bool=False,
                  fov_in_m: float=None,
                  pupil_position:list =[0,0],
@@ -254,12 +255,13 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
         self.n_infinite_phasescreens = len(heights)
         self.last_position = np.zeros(self.n_infinite_phasescreens)
         self.last_t = 0
-        self.delta_time = 1
+        self.delta_time = None
         # fixed at generation time, then is a input -> rescales the screen?
         self.seeing = 0.8
         self.l0 = 0.005
         self.airmass = 1
         self.ref_wavelengthInNm = 500
+        self.extra_delta_time = extra_delta_time
 
         self.inputs['seeing'] = InputValue(type=BaseValue)
         self.inputs['wind_speed'] = InputValue(type=BaseValue)
@@ -356,7 +358,7 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
 
     def prepare_trigger(self, t):
         super().prepare_trigger(t)
-        self.delta_time = self.t_to_seconds(self.current_time - self.last_t)
+        self.delta_time = self.t_to_seconds(self.current_time - self.last_t) + self.extra_delta_time
 
     @show_in_profiler('atmo_evolution.trigger_code')
     def trigger_code(self):

--- a/specula/processing_objects/im_calibrator.py
+++ b/specula/processing_objects/im_calibrator.py
@@ -58,9 +58,9 @@ class ImCalibrator(BaseProcessingObj):
             if self.verbose:
                 print(f"Initialized interaction matrix: {self._im.value.shape}")
 
-        idx = self.xp.nonzero(commands)
+        idx = self.xp.nonzero(commands)[0]
 
-        if len(idx[0])>0:
+        if len(idx)>0:
             mode = int(idx[0]) - self._first_mode
             if mode < self._nmodes:
                 self._im.value[mode] += slopes / commands[idx]

--- a/test/test_atmo_evolution.py
+++ b/test/test_atmo_evolution.py
@@ -8,6 +8,7 @@ import unittest
 from specula import cpuArray
 
 from specula.data_objects.source import Source
+from specula.base_time_obj import BaseTimeObj
 from specula.processing_objects.func_generator import FuncGenerator
 from specula.processing_objects.atmo_evolution import AtmoEvolution
 from specula.processing_objects.atmo_propagation import AtmoPropagation
@@ -244,3 +245,55 @@ class TestAtmoEvolution(unittest.TestCase):
             
         with self.assertRaises(ValueError):
             atmo.setup()
+
+
+    @cpu_and_gpu
+    def test_extra_delta_time(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        seeing = FuncGenerator(constant=0.65, target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[0, 90], target_device_idx=target_device_idx)
+
+        delta_time = 1.0
+        delta_t = BaseTimeObj().seconds_to_t(delta_time)
+        extra_delta_time = 0.1
+
+        atmo = AtmoEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             data_dir=data_dir,
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             extra_delta_time=extra_delta_time,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for objlist in [[seeing, wind_speed, wind_direction], [atmo]]:
+            for obj in objlist:
+                obj.setup()
+
+            for obj in objlist:
+                obj.check_ready(0)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+               obj.post_trigger()
+
+            for obj in objlist:
+                obj.check_ready(delta_t)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+               obj.post_trigger()
+
+        assert atmo.delta_time == delta_time + extra_delta_time

--- a/test/test_atmo_evolution.py
+++ b/test/test_atmo_evolution.py
@@ -160,3 +160,87 @@ class TestAtmoEvolution(unittest.TestCase):
 
         assert id_a1 == id_a2
         assert id_b1 == id_b2
+
+    @cpu_and_gpu
+    def test_wrong_seeing_length_is_checked(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        seeing = FuncGenerator(constant=[0.65, 0.1], target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[0, 90], target_device_idx=target_device_idx)
+
+        atmo = AtmoEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             data_dir=data_dir,
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for obj in [seeing, wind_speed, wind_direction]:
+            obj.setup()
+            
+        with self.assertRaises(ValueError):
+            atmo.setup()
+        
+    @cpu_and_gpu
+    def test_wrong_wind_speed_length_is_checked(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        seeing = FuncGenerator(constant=0.2, target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[8.5, 5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[0, 90], target_device_idx=target_device_idx)
+
+        atmo = AtmoEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             data_dir=data_dir,
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for obj in [seeing, wind_speed, wind_direction]:
+            obj.setup()
+            
+        with self.assertRaises(ValueError):
+            atmo.setup()
+
+    @cpu_and_gpu
+    def test_wrong_wind_speed_direction_is_checked(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        seeing = FuncGenerator(constant=0.2, target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[90, 0, 90], target_device_idx=target_device_idx)
+
+        atmo = AtmoEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             data_dir=data_dir,
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for obj in [seeing, wind_speed, wind_direction]:
+            obj.setup()
+            
+        with self.assertRaises(ValueError):
+            atmo.setup()

--- a/test/test_atmo_infinite_evolution.py
+++ b/test/test_atmo_infinite_evolution.py
@@ -7,6 +7,7 @@ import unittest
 
 from specula import cpuArray
 
+from specula.base_time_obj import BaseTimeObj
 from specula.data_objects.source import Source
 from specula.processing_objects.func_generator import FuncGenerator
 from specula.processing_objects.atmo_infinite_evolution import AtmoInfiniteEvolution
@@ -139,3 +140,53 @@ class TestAtmoInfiniteEvolution(unittest.TestCase):
             
         with self.assertRaises(ValueError):
             atmo.setup()
+
+    @cpu_and_gpu
+    def test_extra_delta_time(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        seeing = FuncGenerator(constant=0.65, target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[0, 90], target_device_idx=target_device_idx)
+
+        delta_time = 1.0
+        delta_t = BaseTimeObj().seconds_to_t(delta_time)
+        extra_delta_time = 0.1
+
+        atmo = AtmoInfiniteEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             extra_delta_time=extra_delta_time,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for objlist in [[seeing, wind_speed, wind_direction], [atmo]]:
+            for obj in objlist:
+                obj.setup()
+
+            for obj in objlist:
+                obj.check_ready(0)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+               obj.post_trigger()
+
+            for obj in objlist:
+                obj.check_ready(delta_t)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+               obj.post_trigger()
+
+        assert atmo.delta_time == delta_time + extra_delta_time

--- a/test/test_atmo_infinite_evolution.py
+++ b/test/test_atmo_infinite_evolution.py
@@ -61,3 +61,81 @@ class TestAtmoInfiniteEvolution(unittest.TestCase):
         for ii in range(len(atmo.outputs['layer_list'])):
             layer = atmo.outputs['layer_list'][ii]
             assert layer.size == (atmo.pixel_layer_size[ii], atmo.pixel_layer_size[ii])
+
+    @cpu_and_gpu
+    def test_wrong_seeing_length_is_checked(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        seeing = FuncGenerator(constant=[0.65, 0.1], target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[0, 90], target_device_idx=target_device_idx)
+
+        atmo = AtmoInfiniteEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for obj in [seeing, wind_speed, wind_direction]:
+            obj.setup()
+            
+        with self.assertRaises(ValueError):
+            atmo.setup()
+        
+    @cpu_and_gpu
+    def test_wrong_wind_speed_length_is_checked(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        seeing = FuncGenerator(constant=0.2, target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[8.5, 5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[0, 90], target_device_idx=target_device_idx)
+
+        atmo = AtmoInfiniteEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for obj in [seeing, wind_speed, wind_direction]:
+            obj.setup()
+            
+        with self.assertRaises(ValueError):
+            atmo.setup()
+
+    @cpu_and_gpu
+    def test_wrong_wind_speed_direction_is_checked(self, target_device_idx, xp):
+
+        simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
+    
+        seeing = FuncGenerator(constant=0.2, target_device_idx=target_device_idx)
+        wind_speed = FuncGenerator(constant=[5.5, 2.3], target_device_idx=target_device_idx)
+        wind_direction = FuncGenerator(constant=[90, 0, 90], target_device_idx=target_device_idx)
+
+        atmo = AtmoInfiniteEvolution(simulParams,
+                             L0=23,  # [m] Outer scale
+                             heights = [30.0000, 26500.0], # [m] layer heights at 0 zenith angle
+                             Cn2 = [0.5, 0.5], # Cn2 weights (total must be eq 1)
+                             fov = 120.0,
+                             target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        for obj in [seeing, wind_speed, wind_direction]:
+            obj.setup()
+            
+        with self.assertRaises(ValueError):
+            atmo.setup()


### PR DESCRIPTION
Deprecation warnings were generated from pytest.
Now it uses value[0] to extract a single array element as instructed by the deprecation warning