### PR TITLE
post_trigger fix

### DIFF
--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -116,10 +116,18 @@ class BaseProcessingObj(BaseTimeObj):
         Make sure we are using the correct device and that any previous
         CUDA graph has been synchronized
         '''
+        # Double check that we can execute
+        if not self.ready:
+            raise RuntimeError('trigger() called when object is not ready')
+
+        # Reset ready flag
+        self.ready = False
+
         if self.target_device_idx>=0:
             self._target_device.use()
             if self.cuda_graph:
                 self.stream.synchronize()
+
 
     def send_remote_output(self, item, dest_rank, dest_tag, first_mpi_send=True, out_name=''):
         if MPI_SEND_DBG: print(process_rank, f'SEND to rank {dest_rank} {dest_tag=} {(dest_tag in self.sent_valid)=} (from {self.name}.{out_name})', flush=True)
@@ -206,22 +214,25 @@ class BaseProcessingObj(BaseTimeObj):
             if self.target_device_idx>=0:
                 self._target_device.use()
             self.prepare_trigger(t)
-            self.ready = True
+            self.ready = True  # Signal ready for trigger and post_trigger()
         else:
+            self.ready = False
             if self.verbose:
                 print(f'No inputs have been refreshed, skipping trigger')
         return self.ready
 
     def trigger(self):
-        if self.ready:
-            with show_in_profiler(self.__class__.__name__+'.trigger'):
-                if self.target_device_idx>=0:
-                    self._target_device.use()
-                if self.target_device_idx>=0 and self.cuda_graph:
-                    self.cuda_graph.launch(stream=self.stream)
-                else:
-                    self.trigger_code()
-            self.ready = False
+        # Double check that we can execute
+        if not self.ready:
+            raise RuntimeError('trigger() called when object is not ready')
+
+        with show_in_profiler(self.__class__.__name__+'.trigger'):
+            if self.target_device_idx>=0:
+                self._target_device.use()
+            if self.target_device_idx>=0 and self.cuda_graph:
+                self.cuda_graph.launch(stream=self.stream)
+            else:
+                self.trigger_code()
              
     @property
     def verbose(self):

--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -30,7 +30,7 @@ class BaseProcessingObj(BaseTimeObj):
 
         # Stream/input management
         self.stream  = None
-        self.ready = False
+        self.inputs_changed = False
         self.cuda_graph = None
 
         # Will be populated by derived class
@@ -117,11 +117,11 @@ class BaseProcessingObj(BaseTimeObj):
         CUDA graph has been synchronized
         '''
         # Double check that we can execute
-        if not self.ready:
-            raise RuntimeError('trigger() called when object is not ready')
+        if not self.inputs_changed:
+            raise RuntimeError("trigger() called when the object's inputs have not changed")
 
-        # Reset ready flag
-        self.ready = False
+        # Reset inputs flag
+        self.inputs_changed = False
 
         if self.target_device_idx>=0:
             self._target_device.use()
@@ -213,18 +213,18 @@ class BaseProcessingObj(BaseTimeObj):
         if self.checkInputTimes():
             if self.target_device_idx>=0:
                 self._target_device.use()
+            self.inputs_changed = True  # Signal ready for trigger and post_trigger()
             self.prepare_trigger(t)
-            self.ready = True  # Signal ready for trigger and post_trigger()
         else:
-            self.ready = False
+            self.inputs_changed = False
             if self.verbose:
                 print(f'No inputs have been refreshed, skipping trigger')
-        return self.ready
+        return self.inputs_changed
 
     def trigger(self):
         # Double check that we can execute
-        if not self.ready:
-            raise RuntimeError('trigger() called when object is not ready')
+        if not self.inputs_changed:
+            raise RuntimeError("trigger() called when the object's inputs have not changed")
 
         with show_in_profiler(self.__class__.__name__+'.trigger'):
             if self.target_device_idx>=0:

--- a/specula/loop_control.py
+++ b/specula/loop_control.py
@@ -131,7 +131,7 @@ class LoopControl(BaseTimeObj):
             if MPI_DBG: print(process_rank, 'before trigger', flush=True)
             for element in self._trigger_lists[i]:
                 try:
-                    if element.ready:
+                    if element.inputs_changed:
                         element.trigger()
                 except:
                     print('Exception in', element.name, flush=True)
@@ -140,7 +140,7 @@ class LoopControl(BaseTimeObj):
             if MPI_DBG: print(process_rank, 'before post_trigger', flush=True)
             for element in self._trigger_lists[i]:
                 try:
-                    if element.ready:
+                    if element.inputs_changed:
                         element.post_trigger()
                     # Always send MPI outputs, regardless of whether
                     # an object was triggered or not

--- a/specula/loop_control.py
+++ b/specula/loop_control.py
@@ -131,7 +131,8 @@ class LoopControl(BaseTimeObj):
             if MPI_DBG: print(process_rank, 'before trigger', flush=True)
             for element in self._trigger_lists[i]:
                 try:
-                    element.trigger()
+                    if element.ready:
+                        element.trigger()
                 except:
                     print('Exception in', element.name, flush=True)
                     raise
@@ -139,7 +140,10 @@ class LoopControl(BaseTimeObj):
             if MPI_DBG: print(process_rank, 'before post_trigger', flush=True)
             for element in self._trigger_lists[i]:
                 try:
-                    element.post_trigger()
+                    if element.ready:
+                        element.post_trigger()
+                    # Always send MPI outputs, regardless of whether
+                    # an object was triggered or not
                     element.send_outputs(skip_delayed=last_iter, first_mpi_send=False)
                 except:
                     print('Exception in', element.name, flush=True)

--- a/test/test_atmo_evolution.py
+++ b/test/test_atmo_evolution.py
@@ -21,7 +21,7 @@ class TestAtmoEvolution(unittest.TestCase):
 
     @cpu_and_gpu
     def test_atmo(self, target_device_idx, xp):
-
+        '''Test that a basic AtmoEvolution and AtmoPropagation setup executes without exceptions'''
         simulParams = SimulParams(pixel_pupil=160, pixel_pitch=0.05, time_step=1)
     
         data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -50,17 +50,18 @@ class TestAtmoEvolution(unittest.TestCase):
         atmo.inputs['wind_speed'].set(wind_speed.output)
         prop.inputs['atmo_layer_list'].set(atmo.outputs['layer_list'])
 
-        for obj in [seeing, wind_speed, wind_direction, atmo, prop]:
-            obj.setup()
-        
-        for obj in [seeing, wind_speed, wind_direction, atmo, prop]:
-            obj.check_ready(1)
-       
-        for obj in [seeing, wind_speed, wind_direction, atmo, prop]:
-            obj.trigger()
+        for objlist in [[seeing, wind_speed, wind_direction], [atmo], [prop]]:
+            for obj in objlist:
+                obj.setup()
 
-        for obj in [seeing, wind_speed, wind_direction, atmo, prop]:
-            obj.post_trigger()
+            for obj in objlist:
+                obj.check_ready(1)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+               obj.post_trigger()
             
         ef_onaxis = cpuArray(prop.outputs['out_on_axis_source_ef'])
         ef_offaxis = cpuArray(prop.outputs['out_lgs1_source_ef'])
@@ -131,29 +132,31 @@ class TestAtmoEvolution(unittest.TestCase):
         atmo.inputs['wind_direction'].set(wind_direction.output)
         atmo.inputs['wind_speed'].set(wind_speed.output)
 
-        for obj in [seeing, wind_speed, wind_direction, atmo]:
-            obj.setup()
-        
-        for obj in [seeing, wind_speed, wind_direction, atmo]:
-            obj.check_ready(1)
-       
-        for obj in [seeing, wind_speed, wind_direction, atmo]:
-            obj.trigger()
+        for objlist in [[seeing, wind_speed, wind_direction], [atmo]]:
+            for obj in objlist:
+                obj.setup()
 
-        for obj in [seeing, wind_speed, wind_direction, atmo]:
-            obj.post_trigger()
+            for obj in objlist:
+                obj.check_ready(1)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+               obj.post_trigger()
 
         id_a1 = id(atmo.outputs['layer_list'][0].field)
         id_b1 = id(atmo.outputs['layer_list'][1].field)
 
-        for obj in [seeing, wind_speed, wind_direction, atmo]:
-            obj.check_ready(2)
-       
-        for obj in [seeing, wind_speed, wind_direction, atmo]:
-            obj.trigger()
+        for objlist in [[seeing, wind_speed, wind_direction], [atmo]]:
+            for obj in objlist:
+                obj.check_ready(2)
 
-        for obj in [seeing, wind_speed, wind_direction, atmo]:
-            obj.post_trigger()
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+               obj.post_trigger()
 
         id_a2 = id(atmo.outputs['layer_list'][0].field)
         id_b2 = id(atmo.outputs['layer_list'][1].field)

--- a/test/test_loop_control.py
+++ b/test/test_loop_control.py
@@ -16,10 +16,10 @@ class MockProcessingObjNotReady(BaseProcessingObj):
         self.ready = False
 
     def trigger(self):
-        raise RuntimError('trigger called when check_ready returned False')
+        raise RuntimeError('trigger called when check_ready returned False')
 
     def post_trigger(self):
-        raise RuntimError('post_trigger called when check_ready returned False')
+        raise RuntimeError('post_trigger called when check_ready returned False')
 
 
 class MockProcessingObjReady(BaseProcessingObj):

--- a/test/test_loop_control.py
+++ b/test/test_loop_control.py
@@ -13,7 +13,7 @@ from test.specula_testlib import cpu_and_gpu
 class MockProcessingObjNotReady(BaseProcessingObj):
     '''Class that is never ready, and raises if trigger() or post_trigger() are called'''
     def check_ready(self, t):
-        self.ready = False
+        self.inputs_changed = False
 
     def trigger(self):
         raise RuntimeError('trigger called when check_ready returned False')
@@ -31,7 +31,7 @@ class MockProcessingObjReady(BaseProcessingObj):
         self.post_triggered = False
 
     def check_ready(self, t):
-        self.ready = True
+        self.inputs_changed = True
 
     def trigger(self):
         self.triggered = True

--- a/test/test_loop_control.py
+++ b/test/test_loop_control.py
@@ -1,0 +1,70 @@
+
+import specula
+specula.init(0)  # Default target device
+
+import unittest
+
+from specula.loop_control import LoopControl
+from specula.base_processing_obj import BaseProcessingObj
+
+from test.specula_testlib import cpu_and_gpu
+
+
+class MockProcessingObjNotReady(BaseProcessingObj):
+    '''Class that is never ready, and raises if trigger() or post_trigger() are called'''
+    def check_ready(self, t):
+        self.ready = False
+
+    def trigger(self):
+        raise RuntimError('trigger called when check_ready returned False')
+
+    def post_trigger(self):
+        raise RuntimError('post_trigger called when check_ready returned False')
+
+
+class MockProcessingObjReady(BaseProcessingObj):
+    '''Class that is alwasy ready and remmebers whether trigger() and post_trigger() were called'''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.triggered = False
+        self.post_triggered = False
+
+    def check_ready(self, t):
+        self.ready = True
+
+    def trigger(self):
+        self.triggered = True
+
+    def post_trigger(self):
+        self.post_triggered = True
+
+
+class TestLoopControl(unittest.TestCase):
+
+    @cpu_and_gpu
+    def test_check_ready_true(self, target_device_idx, xp):
+        '''Test that trigger and post_triggered are called if check_ready is True'''
+
+        loop = LoopControl()
+        p = MockProcessingObjReady()
+
+        loop.add(p, idx=0)
+        loop.run(run_time=1, dt=1)
+
+        assert p.triggered
+        assert p.post_triggered
+
+    @cpu_and_gpu
+    def test_check_ready_False(self, target_device_idx, xp):
+        '''Test that trigger and post_triggered are called if check_ready is False'''
+
+        loop = LoopControl()
+        p = MockProcessingObjNotReady()
+
+        loop.add(p, idx=0)
+        # Must not raise
+        loop.run(run_time=1, dt=1)
+
+
+


### PR DESCRIPTION
ready flag is used for both trigger() and post_trigger()

Since post_trigger() is called by derived classes, we cannot check the ready flag inside the method. Instead, the ready check is moved to loop_control.