### PR TITLE
Replay params

### DIFF
--- a/specula/field_analyser.py
+++ b/specula/field_analyser.py
@@ -227,29 +227,18 @@ class FieldAnalyser:
             print(f"Original DataStore input_list: {original_input_list}")
             print(f"Reduced to DM commands only: {dm_command_inputs}")
 
-        # Create Simul instance by bypassing the constructor
-        temp_simul = object.__new__(Simul)  # Create instance without calling __init__
-
-        # Initialize essential attributes
-        temp_simul.params = modified_params
-        temp_simul.verbose = self.verbose
-        temp_simul.overrides = []
-        temp_simul.diagram = False
-        temp_simul.diagram_title = None
-        temp_simul.diagram_filename = None
-        temp_simul.objs = {}
-        temp_simul.replay_params = {}
+        temp_simul = Simul(['dummy.yml'])
 
         # Build objects and connections (needed for build_replay)
-        temp_simul.build_replay(modified_params)
+        replay_params = temp_simul.build_replay(modified_params)
 
         # Update DataSource store_dir to point to correct tracking number directory
-        if 'data_source' in temp_simul.replay_params:
-            temp_simul.replay_params['data_source']['store_dir'] = str(self.tn_dir)
+        if 'data_source' in replay_params:
+            replay_params['data_source']['store_dir'] = str(self.tn_dir)
             if self.verbose:
                 print(f"Updated DataSource store_dir to: {self.tn_dir}")
 
-        return temp_simul.replay_params
+        return replay_params
 
     def _find_dm_input_sources(self, params: dict) -> set:
         """

--- a/specula/simul.py
+++ b/specula/simul.py
@@ -48,7 +48,6 @@ class Simul():
         self.objs = {}
         self.simul_idx = simul_idx
         self.verbose = False  #TODO
-        self.isReplay = False
         self.mainParams = None
         if overrides is None:
             self.overrides = []
@@ -327,8 +326,6 @@ class Simul():
 
             pars2 = {}
             for name, value in pars.items():
-                if key == 'data_source':
-                    self.isReplay = True
 
                 if key != 'data_source' and name in skip_pars:
                     continue
@@ -512,8 +509,11 @@ class Simul():
 #                    a_connection['end_label'] = self.objs[dest_object].inputs[use_input_name]
                     self.connections.append(a_connection)
 
+    def isReplay(self, params):
+        return 'data_source' in params
+
     def build_replay(self, params):
-        self.replay_params = deepcopy(params)
+        replay_params = deepcopy(params)
         obj_to_remove = []
         data_source_outputs = {}
         for key, pars in params.items():
@@ -523,9 +523,9 @@ class Simul():
                 raise KeyError(f'Object {key} does not define the "class" parameter')
 
             if classname=='DataStore':
-                self.replay_params['data_source'] = self.replay_params[key]
-                self.replay_params['data_source']['class'] = 'DataSource'
-                del self.replay_params[key]
+                replay_params['data_source'] = replay_params[key]
+                replay_params['data_source']['class'] = 'DataSource'
+                del replay_params[key]
                 for output_name_full in pars['inputs']['input_list']:
                     input_name, output_name = output_name_full.split('-')
                     output_obj, output_name_small = output_name.split('.')                     
@@ -533,9 +533,9 @@ class Simul():
                     obj_to_remove.append(output_obj)
 
         for obj_name in set(obj_to_remove):
-            del self.replay_params[obj_name]
+            del replay_params[obj_name]
 
-        for key, pars in self.replay_params.items():
+        for key, pars in replay_params.items():
             if not key=='data_source':
                 if 'inputs' in pars.keys():
                     for input_name, output_name_full in pars['inputs'].items():
@@ -543,18 +543,15 @@ class Simul():
                             print('TODO: list of inputs is not handled in output replay')
                             continue
                         if output_name_full in data_source_outputs.keys():
-                            self.replay_params[key]['inputs'][input_name] = data_source_outputs[output_name_full]
+                            replay_params[key]['inputs'][input_name] = data_source_outputs[output_name_full]
 
             if key=='data_source':
-                self.replay_params[key]['outputs'] = []
-                for v in self.replay_params[key]['inputs']['input_list']:
+                replay_params[key]['outputs'] = []
+                for v in replay_params[key]['inputs']['input_list']:
                     kk, vv = v.split('-')
-                    self.replay_params[key]['outputs'].append(kk)
-                del self.replay_params[key]['inputs']
-
-        for obj in self.objs.values():
-            if type(obj) is DataStore:
-                obj.setReplayParams(self.replay_params)
+                    replay_params[key]['outputs'].append(kk)
+                del replay_params[key]['inputs']
+        return replay_params
 
     def remove_inputs(self, params, obj_to_remove):
         '''
@@ -694,12 +691,16 @@ class Simul():
         print(f'{self.trigger_order=}')
         print(f'{self.trigger_order_idx=}')
 
-        if not self.isReplay:
-            self.build_replay(params)
+        if not self.isReplay(params):
+            replay_params = self.build_replay(params)
 
         self.build_objects(params)
         self.create_input_list_inputs(params)
         self.connect_objects(params)
+
+        for obj in self.objs.values():
+            if type(obj) is DataStore:
+                obj.setReplayParams(replay_params)
 
         # Initialize housekeeping objects
         self.loop = LoopControl()

--- a/specula/simul.py
+++ b/specula/simul.py
@@ -693,14 +693,17 @@ class Simul():
 
         if not self.isReplay(params):
             replay_params = self.build_replay(params)
+        else:
+            replay_params = None
 
         self.build_objects(params)
         self.create_input_list_inputs(params)
         self.connect_objects(params)
 
-        for obj in self.objs.values():
-            if type(obj) is DataStore:
-                obj.setReplayParams(replay_params)
+        if replay_params is not None:
+            for obj in self.objs.values():
+                if type(obj) is DataStore:
+                    obj.setReplayParams(replay_params)
 
         # Initialize housekeeping objects
         self.loop = LoopControl()

--- a/test/test_data_store.py
+++ b/test/test_data_store.py
@@ -56,4 +56,4 @@ class TestDataStore(unittest.TestCase):
 
         # Make sure replay_params.yml exists
         replay_file = os.path.join(last_tn_dir, 'replay_params.yml')
-        assert os.path.exists(gen_file), f"File {replay_file} does not exist"
+        assert os.path.exists(replay_file), f"File {replay_file} does not exist"

--- a/test/test_data_store.py
+++ b/test/test_data_store.py
@@ -53,3 +53,7 @@ class TestDataStore(unittest.TestCase):
         # Make sure times are in int64
         gen_times = fits.getdata(gen_file, ext=1)
         assert gen_times.dtype == np.uint64
+
+        # Make sure replay_params.yml exists
+        replay_file = os.path.join(last_tn_dir, 'replay_params.yml')
+        assert os.path.exists(gen_file), f"File {replay_file} does not exist"


### PR DESCRIPTION
Some time ago, after an update to the parameter handling, the replay_params file stopped being generated but there was no test to catch it.
This PR moves the replay params generation after object creation, where it works again, and adds a test.