### PR TITLE
Added option for external modules

### DIFF
--- a/specula/data_objects/simul_params.py
+++ b/specula/data_objects/simul_params.py
@@ -1,6 +1,6 @@
 
 from specula.base_data_obj import BaseDataObj
-
+from typing import List
 
 class SimulParams(BaseDataObj):
     '''
@@ -31,6 +31,7 @@ class SimulParams(BaseDataObj):
                 time_step: float = 0.001,
                 zenithAngleInDeg: float = 0,
                 display_server: bool = False,
+                add_modules: List[str] = [],
     ):
         super().__init__()
         self.pixel_pupil = pixel_pupil
@@ -40,3 +41,4 @@ class SimulParams(BaseDataObj):
         self.time_step = time_step
         self.zenithAngleInDeg = zenithAngleInDeg
         self.display_server = display_server
+        self.add_modules = add_modules

--- a/specula/simul.py
+++ b/specula/simul.py
@@ -282,7 +282,8 @@ class Simul():
             except KeyError:
                 raise KeyError(f'Object {key} does not define the "class" parameter')
 
-            klass = import_class(classname)
+            additional_modules = self.mainParams['add_modules']
+            klass = import_class(classname, additional_modules)
             args = inspect.getfullargspec(getattr(klass, '__init__')).args
             hints = get_type_hints(klass)
 

--- a/specula/simul.py
+++ b/specula/simul.py
@@ -271,6 +271,10 @@ class Simul():
 
         cm = CalibManager(self.mainParams['root_dir'])
         skip_pars = 'class inputs outputs'.split()
+        if 'add_modules' in self.mainParams:
+            additional_modules = self.mainParams['add_modules']
+        else:
+            additional_modules = []
 
         if MPI_DBG: print(process_rank, 'building objects')
 
@@ -282,7 +286,6 @@ class Simul():
             except KeyError:
                 raise KeyError(f'Object {key} does not define the "class" parameter')
 
-            additional_modules = self.mainParams['add_modules']
             klass = import_class(classname, additional_modules)
             args = inspect.getfullargspec(getattr(klass, '__init__')).args
             hints = get_type_hints(klass)

--- a/test/test_import_class.py
+++ b/test/test_import_class.py
@@ -1,0 +1,155 @@
+import unittest
+import importlib
+from unittest.mock import patch, MagicMock
+from specula.lib.utils import import_class
+
+class TestImportClass(unittest.TestCase):
+    """
+    Unit tests for the `import_class` function in specula.lib.utils.
+    
+    The tests verify correct behavior in all major scenarios:
+    - Successful import from default modules
+    - Successful import from additional user-defined modules
+    - Raising AttributeError when class is missing
+    - Raising ImportError when module is missing
+    - Correct fallback behavior when earlier modules fail
+    """
+
+    def test_successful_import_from_first_module(self):
+        """
+        Test that `import_class` correctly imports a class from the first
+        default module (specula.processing_objects).
+
+        This test mocks `camelcase_to_snakecase` to return a fixed module name,
+        and mocks `importlib.import_module` to return a module containing the
+        expected class. The test asserts that the returned class is correct and
+        that both mocks are called as expected.
+        """
+        with patch("specula.lib.utils.camelcase_to_snakecase", return_value="my_class") as mock_snake, \
+             patch("specula.lib.utils.importlib.import_module") as mock_import:
+
+            # Fake module + class
+            mock_module = MagicMock()
+            mock_class = type("MyClass", (), {})
+            setattr(mock_module, "MyClass", mock_class)
+            mock_import.return_value = mock_module
+
+            result = import_class("MyClass")
+
+            self.assertEqual(result, mock_class)
+            self.assertTrue(mock_snake.called)
+            mock_snake.assert_called_with("MyClass")
+            mock_import.assert_called_with("specula.processing_objects.my_class")
+
+    def test_successful_import_from_additional_module(self):
+        """
+        Test that `import_class` can successfully import a class from a
+        user-provided additional module when all default modules fail.
+
+        The test simulates ModuleNotFoundError for the default modules
+        (processing_objects, data_objects, display) and provides a mock
+        module in `custom.module` that contains the target class. It asserts
+        that the correct class is returned and that import_module is called
+        for the additional module.
+        """
+        with patch("specula.lib.utils.camelcase_to_snakecase", return_value="my_class") as mock_snake, \
+             patch("specula.lib.utils.importlib.import_module") as mock_import:
+
+            def side_effect(module_path):
+                if module_path in [
+                    "specula.processing_objects.my_class",
+                    "specula.data_objects.my_class",
+                    "specula.display.my_class",
+                ]:
+                    raise ModuleNotFoundError
+                elif module_path == "custom.module.my_class":
+                    mock_module = MagicMock()
+                    mock_class = type("MyClass", (), {})
+                    setattr(mock_module, "MyClass", mock_class)
+                    return mock_module
+                else:
+                    raise ModuleNotFoundError
+
+            mock_import.side_effect = side_effect
+
+            result = import_class("MyClass", additional_modules=["custom.module"])
+            self.assertEqual(result.__name__, "MyClass")
+            self.assertTrue(mock_snake.called)
+            mock_import.assert_any_call("custom.module.my_class")
+
+
+    def test_class_not_found_in_module(self):
+        """
+        Test that `import_class` raises AttributeError when the module exists
+        but does not contain the expected class.
+
+        This test mocks import_module to return a MagicMock that does not
+        include the class attribute. It verifies that AttributeError is raised
+        and that camelcase_to_snakecase and import_module are called.
+        """
+        with patch("specula.lib.utils.camelcase_to_snakecase", return_value="my_class") as mock_snake, \
+             patch("specula.lib.utils.importlib.import_module") as mock_import:
+
+            mock_module = MagicMock()
+            # Ensure MyClass does not exist
+            if hasattr(mock_module, "MyClass"):
+                del mock_module.MyClass
+            mock_import.return_value = mock_module
+
+            mock_import.return_value = mock_module
+
+            with self.assertRaises(AttributeError):
+                import_class("MyClass")
+
+            self.assertTrue(mock_snake.called)
+            mock_import.assert_called_with("specula.processing_objects.my_class")
+
+    def test_module_not_found_raises_import_error(self):
+        """
+        Test that `import_class` raises ImportError when the class cannot
+        be found in any module.
+
+        This simulates ModuleNotFoundError for all attempts to import modules.
+        It asserts that the function raises ImportError and that
+        camelcase_to_snakecase is called.
+        """
+        with patch("specula.lib.utils.camelcase_to_snakecase", return_value="my_class") as mock_snake, \
+             patch("specula.lib.utils.importlib.import_module") as mock_import:
+
+            mock_import.side_effect = ModuleNotFoundError
+
+            with self.assertRaises(ImportError):
+                import_class("MyClass")
+
+            self.assertTrue(mock_snake.called)
+
+    def test_fallback_to_later_module(self):
+        """
+        Test that `import_class` correctly falls back to later default modules
+        when earlier ones are missing.
+
+        The test simulates ModuleNotFoundError for 'processing_objects' and
+        'data_objects', then provides a module for 'display'. It verifies that
+        the returned class is correct and that import_module was called on
+        the fallback module.
+        """
+        with patch("specula.lib.utils.camelcase_to_snakecase", return_value="my_class") as mock_snake, \
+             patch("specula.lib.utils.importlib.import_module") as mock_import:
+
+            def side_effect(module_path):
+                if module_path in [
+                    "specula.processing_objects.my_class",
+                    "specula.data_objects.my_class",
+                ]:
+                    raise ModuleNotFoundError
+                mock_module = MagicMock()
+                mock_class = type("MyClass", (), {})
+                setattr(mock_module, "MyClass", mock_class)
+                return mock_module
+
+            mock_import.side_effect = side_effect
+
+            result = import_class("MyClass")
+            self.assertEqual(result.__name__, "MyClass")
+            self.assertTrue(mock_snake.called)
+            mock_import.assert_any_call("specula.display.my_class")


### PR DESCRIPTION
Added keyword in simulparams to look for processing objects in additional modules, for example in speculab for laboratory interfaces:

```
main:
  class:             'SimulParams'
  root_dir:          './calib/'             # Root directory for calibration manager 
  pixel_pupil:       160                    # Linear dimension of pupil phase array
  pixel_pitch:       0.05                   # [m] Pitch of the pupil phase array
  total_time:        0.010                  # [s] Total simulation running time
  time_step:         0.001                  # [s] Simulation time step
  add_modules:      ['speculab']

```