### PR TITLE
setup.py reads requirements from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ astro-seeing>=1.1
 flask-socketio
 python-socketio
 requests
+pytest

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ class UploadCommand(Command):
 
         sys.exit()
 
+# Read dependencies from requirements.txt
+with open("requirements.txt") as f:
+    requirements = f.read().splitlines()
 
 setup(name=NAME,
       description=DESCRIPTION,
@@ -84,16 +87,7 @@ setup(name=NAME,
           ],
       },
       python_requires='>=3.8.0',
-      install_requires=["numpy",
-                        "scipy",
-                        "astropy",
-                        "matplotlib",
-                        "astro-seeing>=1.1",
-                        "symao>=1.0.1",
-                        "flask-socketio",
-                        "python-socketio",
-                        "requests"
-                        ],
+      install_requires=requirements,
       extras_require={
           'control': ["iircontrol"]
       },


### PR DESCRIPTION
Removed the duplicate requirement lists, now there is only one in requirements.txt
Tested by installing in a new conda environment