### PR TITLE
Fixed test warnings on MacOS

### DIFF
--- a/test/test_display.py
+++ b/test/test_display.py
@@ -35,6 +35,7 @@ class TestDisplays(unittest.TestCase):
         self.S0 = 1.0
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
+    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_phase_display_init_and_trigger(self, target_device_idx, xp):
         """Test PhaseDisplay initialization and trigger"""
@@ -59,6 +60,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
+    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_pixels_display_init_and_trigger(self, target_device_idx, xp):
         """Test PixelsDisplay initialization and trigger"""
@@ -83,6 +85,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
+    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_slopec_display_init_and_trigger(self, target_device_idx, xp):
         """Test SlopecDisplay initialization and trigger"""
@@ -107,6 +110,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
+    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_psf_display_init_and_trigger(self, target_device_idx, xp):
         """Test PsfDisplay initialization and trigger"""
@@ -139,6 +143,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
+    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_modes_display_trigger(self, target_device_idx, xp):
         """Test ModesDisplay trigger functionality"""
@@ -165,6 +170,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
+    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_plot_display_trigger(self, target_device_idx, xp):
         """Test PlotDisplay trigger functionality"""

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -35,7 +35,7 @@ class TestDisplays(unittest.TestCase):
         self.S0 = 1.0
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_phase_display_init_and_trigger(self, target_device_idx, xp):
         """Test PhaseDisplay initialization and trigger"""
@@ -60,7 +60,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_pixels_display_init_and_trigger(self, target_device_idx, xp):
         """Test PixelsDisplay initialization and trigger"""
@@ -85,7 +85,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_slopec_display_init_and_trigger(self, target_device_idx, xp):
         """Test SlopecDisplay initialization and trigger"""
@@ -110,7 +110,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_psf_display_init_and_trigger(self, target_device_idx, xp):
         """Test PsfDisplay initialization and trigger"""
@@ -143,7 +143,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_modes_display_trigger(self, target_device_idx, xp):
         """Test ModesDisplay trigger functionality"""
@@ -170,7 +170,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mask.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_plot_display_trigger(self, target_device_idx, xp):
         """Test PlotDisplay trigger functionality"""

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -35,7 +35,7 @@ class TestDisplays(unittest.TestCase):
         self.S0 = 1.0
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore:.*Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_phase_display_init_and_trigger(self, target_device_idx, xp):
         """Test PhaseDisplay initialization and trigger"""
@@ -60,7 +60,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore:.*Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_pixels_display_init_and_trigger(self, target_device_idx, xp):
         """Test PixelsDisplay initialization and trigger"""
@@ -85,7 +85,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore:.*Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_slopec_display_init_and_trigger(self, target_device_idx, xp):
         """Test SlopecDisplay initialization and trigger"""
@@ -110,7 +110,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore:.*Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_psf_display_init_and_trigger(self, target_device_idx, xp):
         """Test PsfDisplay initialization and trigger"""
@@ -143,7 +143,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore:.*Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_modes_display_trigger(self, target_device_idx, xp):
         """Test ModesDisplay trigger functionality"""
@@ -170,7 +170,7 @@ class TestDisplays(unittest.TestCase):
         display.close()
 
     @pytest.mark.filterwarnings('ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning')
-    @pytest.mark.filterwarnings('ignore: *Matplotlib is currently using agg*:UserWarning')
+    @pytest.mark.filterwarnings('ignore:.*Matplotlib is currently using agg*:UserWarning')
     @cpu_and_gpu
     def test_plot_display_trigger(self, target_device_idx, xp):
         """Test PlotDisplay trigger functionality"""


### PR DESCRIPTION
Fixes a warning during tests on MacOSX because Matplotlib is using the non-interactive "Agg" backend