### PR TITLE
(GA) Updates to InfinitePhaseScreen and disabled test for issue in Continuous Integration

### DIFF
--- a/specula/data_objects/infinite_phase_screen.py
+++ b/specula/data_objects/infinite_phase_screen.py
@@ -24,7 +24,8 @@ def cn2_to_seeing(cn2, wvl=500.e-9):
 
 class InfinitePhaseScreen(BaseDataObj):
 
-    def __init__(self, mx_size, pixel_scale, r0, L0, random_seed=None, stencil_size_factor=1, xp=np, target_device_idx=0, precision=0):
+    def __init__(self, mx_size, pixel_scale, r0, L0, random_seed=None, stencil_size_factor=1, xp=None,
+                 target_device_idx=0, precision=0):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
 
         self.random_data_col = None
@@ -34,13 +35,27 @@ class InfinitePhaseScreen(BaseDataObj):
         self.pixel_scale = pixel_scale
         self.r0 = r0
         self.L0 = L0
-        self.xp = xp
+        if xp is not None:
+            self.xp = xp
         self.stencil_size_factor = stencil_size_factor
-        
+
         # stencil size must be odd and >= 257
         base_stencil_size = int(stencil_size_factor * self.mx_size/2)*2 + 1
         min_stencil_size = 257
         self.stencil_size = max(base_stencil_size, min_stencil_size)
+
+        self.stencil = None
+        self.stencil_coords = None
+        self.stencil_positions = None
+        self.n_stencils = 0
+        self.cov_mat = None
+        self.cov_mat_zz = None
+        self.cov_mat_xx = None
+        self.cov_mat_zx = None
+        self.cov_mat_xz = None
+        self.full_scrn = None
+        self.A_mat = None
+        self.B_mat = None
 
         if random_seed is None:
             raise ValueError("random_seed must be provided")
@@ -107,10 +122,10 @@ class InfinitePhaseScreen(BaseDataObj):
     def AB_from_positions(self, positions):
         seperations = self.xp.zeros((len(positions), len(positions)))
         px, py = positions[:,0], positions[:,1]
-        delta_x_gridA, delta_x_gridB = self.xp.meshgrid(px, px)
-        delta_y_gridA, delta_y_gridB = self.xp.meshgrid(py, py)
-        delta_x_grid = delta_x_gridA - delta_x_gridB
-        delta_y_grid = delta_y_gridA - delta_y_gridB
+        delta_x_grid_a, delta_x_grid_b = self.xp.meshgrid(px, px)
+        delta_y_grid_a, delta_y_grid_b = self.xp.meshgrid(py, py)
+        delta_x_grid = delta_x_grid_a - delta_x_grid_b
+        delta_y_grid = delta_y_grid_a - delta_y_grid_b
         seperations = self.xp.sqrt(delta_x_grid ** 2 + delta_y_grid ** 2)
         self.cov_mat = self.phase_covariance(seperations, self.r0, self.L0)
         self.cov_mat_zz = self.cov_mat[:self.n_stencils, :self.n_stencils]

--- a/specula/data_objects/infinite_phase_screen.py
+++ b/specula/data_objects/infinite_phase_screen.py
@@ -1,10 +1,10 @@
 from seeing.integrator import evaluateFormula, cpulib
 from symao.turbolence import createTurbolenceFormulary, ft_phase_screen0
 
+turbolenceFormulas = createTurbolenceFormulary()
+
 from specula.base_data_obj import BaseDataObj
 from specula import ASEC2RAD, RAD2ASEC, cpuArray, np
-
-turbolenceFormulas = createTurbolenceFormulary()
 
 def seeing_to_r0(seeing, wvl=500.e-9):
     return 0.9759*wvl/(seeing* ASEC2RAD)
@@ -25,7 +25,7 @@ def cn2_to_seeing(cn2, wvl=500.e-9):
 class InfinitePhaseScreen(BaseDataObj):
 
     def __init__(self, mx_size, pixel_scale, r0, L0, random_seed=None, stencil_size_factor=1, xp=None,
-                 target_device_idx=0, precision=0):
+                 target_device_idx=None, precision=None):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
 
         self.random_data_col = None

--- a/specula/data_objects/infinite_phase_screen.py
+++ b/specula/data_objects/infinite_phase_screen.py
@@ -1,14 +1,8 @@
-import numpy as np
+from seeing.integrator import evaluateFormula, cpulib
+from symao.turbolence import createTurbolenceFormulary, ft_phase_screen0
 
 from specula.base_data_obj import BaseDataObj
-from specula import ASEC2RAD, RAD2ASEC, cpuArray
-
-from seeing.sympyHelpers import *
-from seeing.formulary import *
-from seeing.integrator import *
-
-# from scipy.special import gamma, kv
-from symao.turbolence import createTurbolenceFormulary, ft_phase_screen0
+from specula import ASEC2RAD, RAD2ASEC, cpuArray, np
 
 turbolenceFormulas = createTurbolenceFormulary()
 

--- a/specula/processing_objects/atmo_infinite_evolution.py
+++ b/specula/processing_objects/atmo_infinite_evolution.py
@@ -114,11 +114,13 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
         self.acc_cols = np.zeros((self.n_infinite_phasescreens))
 
         # Square infinite_phasescreens
+        print('Creating phase screens..')
         for i in range(self.n_infinite_phasescreens):
-            print('Creating phase screen..')
             self.ref_r0 = 0.9759 * 0.5 / (self.seeing * 4.848) * self.airmass**(-3./5.) # if seeing > 0 else 0.0
             self.ref_r0 *= (self.ref_wavelengthInNm / 500.0 )**(6./5.)
-            print('self.ref_r0:', self.ref_r0)
+            if self.verbose:
+                print(f'Creating {i}-th phase screen')
+                print(f'    r0: {self.ref_r0}, L0: {self.L0[i]}, size: {self.pixel_layer_size[i]}')
             temp_infinite_screen = InfinitePhaseScreen(self.pixel_layer_size[i],
                                                        self.pixel_pitch,
                                                        self.ref_r0,

--- a/specula/processing_objects/atmo_infinite_evolution.py
+++ b/specula/processing_objects/atmo_infinite_evolution.py
@@ -118,7 +118,7 @@ class AtmoInfiniteEvolution(BaseProcessingObj):
         for i in range(self.n_infinite_phasescreens):
             self.ref_r0 = 0.9759 * 0.5 / (self.seeing * 4.848) * self.airmass**(-3./5.) # if seeing > 0 else 0.0
             self.ref_r0 *= (self.ref_wavelengthInNm / 500.0 )**(6./5.)
-            if self.verbose:
+            if self.verbose: # pragma: no cover
                 print(f'Creating {i}-th phase screen')
                 print(f'    r0: {self.ref_r0}, L0: {self.L0[i]}, size: {self.pixel_layer_size[i]}')
             temp_infinite_screen = InfinitePhaseScreen(self.pixel_layer_size[i],

--- a/test/test_atmo_infinite_evolution.py
+++ b/test/test_atmo_infinite_evolution.py
@@ -248,8 +248,8 @@ class TestAtmoInfiniteEvolution(unittest.TestCase):
         seeing1, seeing2 = seeing_values
         result1, result2 = results
 
-        print(f"Seeing 1: {seeing1} arcsec, scale_coeff: {result1['scale_coeff']:.6f}")
-        print(f"Seeing 2: {seeing2} arcsec, scale_coeff: {result2['scale_coeff']:.6f}")
+        #print(f"Seeing 1: {seeing1} arcsec, scale_coeff: {result1['scale_coeff']:.6f}")
+        #print(f"Seeing 2: {seeing2} arcsec, scale_coeff: {result2['scale_coeff']:.6f}")
 
         # Test 1: Verify that scale_coeff is scaling with seeing
         seeing_ratio = result1['scale_coeff'] / result2['scale_coeff']
@@ -267,7 +267,7 @@ class TestAtmoInfiniteEvolution(unittest.TestCase):
             rms1 = float(xp.sqrt(xp.mean(phase1**2)))
             rms2 = float(xp.sqrt(xp.mean(phase2**2)))
 
-            print(f"Layer {i}: RMS phase seeing={seeing1}: {rms1:.3f}, seeing={seeing2}: {rms2:.3f}")
+            #print(f"Layer {i}: RMS phase seeing={seeing1}: {rms1:.3f}, seeing={seeing2}: {rms2:.3f}")
 
             # Check that the RMS ratio matches the expected seeing ratio
             self.assertAlmostEqual(rms1/rms2, expected_seeing_ratio, places=2,
@@ -291,3 +291,154 @@ class TestAtmoInfiniteEvolution(unittest.TestCase):
                                     target_device_idx=target_device_idx)
         expected = cpuArray(heights) * airmass
         np.testing.assert_allclose(atmo.pupil_distances, expected, rtol=1e-8)
+
+    @cpu_and_gpu
+    def test_cn2_scaling_applied_correctly(self, target_device_idx, xp):
+        """
+        Test that Cn2 weights are correctly applied to the phase screens
+        """
+        pixel_pupil = 160
+        simul_params = SimulParams(pixel_pupil=pixel_pupil, pixel_pitch=0.05, time_step=1)
+
+        # Test with different Cn2 values for two layers
+        cn2_values = [0.7, 0.3]  # Different weights for the layers
+        heights = [1000.0, 5000.0]
+
+        seeing = WaveGenerator(constant=0.8, target_device_idx=target_device_idx)
+        wind_speed = WaveGenerator(constant=[5.0, 3.0], target_device_idx=target_device_idx)
+        wind_direction = WaveGenerator(constant=[0, 45], target_device_idx=target_device_idx)
+
+        atmo = AtmoInfiniteEvolution(simul_params,
+                                    L0=1,
+                                    heights=heights,
+                                    Cn2=cn2_values,
+                                    fov=120.0,
+                                    target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        # Setup and run one iteration
+        for objlist in [[seeing, wind_speed, wind_direction], [atmo]]:
+            for obj in objlist:
+                obj.setup()
+
+            for obj in objlist:
+                obj.check_ready(1)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+                obj.post_trigger()
+
+        # Get phases from both layers
+        phase_layer0 = cpuArray(atmo.layer_list[0].phaseInNm)
+        phase_layer1 = cpuArray(atmo.layer_list[1].phaseInNm)
+
+        # Calculate RMS for each layer
+        rms_layer0 = float(np.sqrt(np.mean(phase_layer0**2)))
+        rms_layer1 = float(np.sqrt(np.mean(phase_layer1**2)))
+
+        #print(f"Layer 0 (Cn2={cn2_values[0]}): RMS = {rms_layer0:.3f} nm")
+        #print(f"Layer 1 (Cn2={cn2_values[1]}): RMS = {rms_layer1:.3f} nm")
+
+        # Test 1: Verify that the RMS ratio matches the sqrt(Cn2) ratio
+        # Since phase is scaled by scale_coeff * sqrt(Cn2[i])
+        expected_rms_ratio = np.sqrt(cn2_values[0]) / np.sqrt(cn2_values[1])
+        actual_rms_ratio = rms_layer0 / rms_layer1
+
+        self.assertAlmostEqual(actual_rms_ratio, expected_rms_ratio, places=1,
+            msg=f"RMS ratio {actual_rms_ratio:.3f} should equal sqrt(Cn2[0]/Cn2[1]) = {expected_rms_ratio:.3f}")
+
+        # Test 2: Verify that both layers have the same base variance (before Cn2 scaling)
+        # Base variance = (RMS / sqrt(Cn2))^2
+        base_variance_0 = (rms_layer0 / np.sqrt(cn2_values[0]))**2
+        base_variance_1 = (rms_layer1 / np.sqrt(cn2_values[1]))**2
+
+        #print(f"Base variance 0: {base_variance_0:.3f}")
+        #print(f"Base variance 1: {base_variance_1:.3f}")
+
+        # The base variances should be approximately equal (within tolerance for numerical differences)
+        self.assertAlmostEqual(base_variance_0, base_variance_1, delta=base_variance_0 * 0.1,
+            msg=f"Base variances should be approximately equal: {base_variance_0:.3f} vs {base_variance_1:.3f}")
+
+        # Test 3: Verify that the total Cn2-weighted variance makes sense
+        total_cn2_weighted_variance = cn2_values[0] * base_variance_0 + cn2_values[1] * base_variance_1
+        expected_total = base_variance_0  # Should be approximately equal to the base variance
+
+        self.assertAlmostEqual(total_cn2_weighted_variance, expected_total, delta=expected_total * 0.1,
+            msg=f"Total Cn2-weighted variance {total_cn2_weighted_variance:.3f} should equal base variance {expected_total:.3f}")
+
+    @cpu_and_gpu
+    def test_cn2_sum_validation(self, target_device_idx, xp):
+        """
+        Test that Cn2 values must sum to 1.0
+        """
+        pixel_pupil = 160
+        simul_params = SimulParams(pixel_pupil=pixel_pupil, pixel_pitch=0.05, time_step=1)
+
+        # Test with Cn2 values that don't sum to 1
+        with self.assertRaises(ValueError) as context:
+            atmo = AtmoInfiniteEvolution(simul_params,
+                                        L0=1,
+                                        heights=[1000.0, 5000.0],
+                                        Cn2=[0.6, 0.5],  # Sum = 1.1, not 1.0
+                                        fov=120.0,
+                                        target_device_idx=target_device_idx)
+
+        self.assertIn("Cn2 total must be 1", str(context.exception))
+
+    @cpu_and_gpu
+    def test_single_layer_cn2_scaling(self, target_device_idx, xp):
+        """
+        Test Cn2 scaling with a single layer
+        """
+        pixel_pupil = 160
+        simul_params = SimulParams(pixel_pupil=pixel_pupil, pixel_pitch=0.05, time_step=1)
+
+        cn2_values = [1.0]  # Single layer with all turbulence
+
+        seeing = WaveGenerator(constant=0.8, target_device_idx=target_device_idx)
+        wind_speed = WaveGenerator(constant=[4.0], target_device_idx=target_device_idx)
+        wind_direction = WaveGenerator(constant=[30], target_device_idx=target_device_idx)
+
+        atmo = AtmoInfiniteEvolution(simul_params,
+                                    L0=1,
+                                    heights=[2000.0],
+                                    Cn2=cn2_values,
+                                    fov=120.0,
+                                    target_device_idx=target_device_idx)
+
+        atmo.inputs['seeing'].set(seeing.output)
+        atmo.inputs['wind_direction'].set(wind_direction.output)
+        atmo.inputs['wind_speed'].set(wind_speed.output)
+
+        # Setup and run
+        for objlist in [[seeing, wind_speed, wind_direction], [atmo]]:
+            for obj in objlist:
+                obj.setup()
+
+            for obj in objlist:
+                obj.check_ready(1)
+
+            for obj in objlist:
+                obj.trigger()
+
+            for obj in objlist:
+                obj.post_trigger()
+
+        # Get phase from the single layer
+        phase_layer = cpuArray(atmo.layer_list[0].phaseInNm)
+        rms_phase = float(np.sqrt(np.mean(phase_layer**2)))
+
+        print(f"Single layer (Cn2=1.0): RMS = {rms_phase:.3f} nm")
+
+        # With Cn2=1.0, the phase should be scaled by sqrt(1.0) = 1.0
+        # So the RMS should be the base RMS from the infinite phase screen
+        self.assertGreater(rms_phase, 0, "Phase RMS should be positive")
+
+        # Verify that the layer has the correct generation time and amplitude
+        self.assertEqual(atmo.layer_list[0].generation_time, atmo.current_time)
+        np.testing.assert_array_equal(cpuArray(atmo.layer_list[0].A), 1)

--- a/test/test_atmo_simulation.py
+++ b/test/test_atmo_simulation.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import glob
 import specula
-specula.init(-1,precision=1)  # Default target device
+specula.init(-1,precision=0)  # Default target device
 
 from specula import np
 from specula.simul import Simul

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-import signal
+import threading
 import specula
 specula.init(-1,precision=1)  # Default target device
 
@@ -8,6 +8,7 @@ from specula import np
 from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 from specula.lib.calc_phasescreen import calc_phasescreen
 
+#@unittest.skipIf(os.environ.get('CI') == 'true', "Debugging CI issues")
 class TestInfinitePhaseScreen(unittest.TestCase):
 
     def test_phase_covariance_matches_theory(self):
@@ -48,13 +49,12 @@ class TestInfinitePhaseScreen(unittest.TestCase):
         L0 = 25.0  # meters
         random_seed1 = 42
         random_seed2 = 1042
-        n_seeds = 3
 
         # Test parameter combinations
         if os.environ.get('CI') == 'true':
             phase_sizes = [128]
             pixel_scales = [0.5]
-            n_seeds = 5
+            n_seeds = 3
             timeout = 60
         else:
             phase_sizes = [512]
@@ -71,11 +71,15 @@ class TestInfinitePhaseScreen(unittest.TestCase):
             print(f"{'Phase Size':<12} {'Pixel Scale':<12} {'Inf Mean':<10} {'Inf Std':<10} {'FFT Mean':<10} {'FFT Std':<10} {'Ratio':<8}")
             print("-" * 76)
 
-        def timeout_handler(signum, frame):
-            raise TimeoutError("Test timeout exceeded")
+        test_completed = threading.Event()
+        timeout_occurred = threading.Event()
 
-        signal.signal(signal.SIGALRM, timeout_handler)
-        signal.alarm(timeout)
+        def timeout_handler():
+            if not test_completed.is_set():
+                timeout_occurred.set()
+
+        timer = threading.Timer(timeout, timeout_handler)
+        timer.start()
 
         try:
             for phase_size in phase_sizes:
@@ -132,6 +136,8 @@ class TestInfinitePhaseScreen(unittest.TestCase):
                     if verbose:
                         print(f"{phase_size:<12} {pixel_scale:<12} {inf_mean:<10.6f} {inf_std:<10.1f} {fft_mean:<10.6f} {fft_std:<10.1f} {std_ratio:<8.3f}")
 
+            test_completed.set()
+
             # Overall statistics
             all_ratios = [r['std_ratio'] for r in results if r['std_ratio'] > 0]
             min_ratio = np.min(all_ratios)
@@ -171,7 +177,7 @@ class TestInfinitePhaseScreen(unittest.TestCase):
                     print(f"  ... and {len(failed_tests) - 10} more")
 
         finally:
-            signal.alarm(0)
+            timer.cancel()
 
     def test_reproducibility_with_same_seed(self):
         """Test that screens with same seed produce identical results"""

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -1,18 +1,17 @@
 import unittest
 import os
-import threading
 import specula
-specula.init(-1,precision=1)  # Default target device
+specula.init(-1,precision=0)  # Default target device
 
 from specula import np
-from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
-from specula.lib.calc_phasescreen import calc_phasescreen
 
-#@unittest.skipIf(os.environ.get('CI') == 'true', "Debugging CI issues")
+@unittest.skipIf(os.environ.get('CI') == 'true', "Debugging CI issues")
 class TestInfinitePhaseScreen(unittest.TestCase):
 
     def test_phase_covariance_matches_theory(self):
         """Test that the phase covariance function matches theoretical values"""
+
+        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         # Parameters
         mx_size = 512
@@ -42,6 +41,9 @@ class TestInfinitePhaseScreen(unittest.TestCase):
         """Compare statistics between InfinitePhaseScreen and calc_phasescreen (FFT method)
         across multiple combinations of phase_size and pixel_scale"""
 
+        from specula.lib.calc_phasescreen import calc_phasescreen
+        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
+
         verbose = False
 
         # Parameters
@@ -55,12 +57,10 @@ class TestInfinitePhaseScreen(unittest.TestCase):
             phase_sizes = [128]
             pixel_scales = [0.5]
             n_seeds = 3
-            timeout = 60
         else:
             phase_sizes = [512]
             pixel_scales = [0.5, 0.05]
             n_seeds = 10
-            timeout = 60
 
         # Store all results for summary
         results = []
@@ -71,116 +71,102 @@ class TestInfinitePhaseScreen(unittest.TestCase):
             print(f"{'Phase Size':<12} {'Pixel Scale':<12} {'Inf Mean':<10} {'Inf Std':<10} {'FFT Mean':<10} {'FFT Std':<10} {'Ratio':<8}")
             print("-" * 76)
 
-        test_completed = threading.Event()
-        timeout_occurred = threading.Event()
+        for phase_size in phase_sizes:
+            for pixel_scale in pixel_scales:
+                # Initialize accumulators
+                inf_mean = 0
+                inf_std = 0
+                fft_mean = 0
+                fft_std = 0
 
-        def timeout_handler():
-            if not test_completed.is_set():
-                timeout_occurred.set()
+                for i in range(n_seeds):
+                    # Create infinite phase screen
+                    r0_inf = r0 #2 * pixel_scale
+                    ips = InfinitePhaseScreen(phase_size, pixel_scale, r0_inf, L0,
+                                            random_seed=random_seed1 + i,
+                                            target_device_idx=-1)
 
-        timer = threading.Timer(timeout, timeout_handler)
-        timer.start()
+                    # Get initial phase screen
+                    infinite_screen = ips.scrn * 500 / (2 * np.pi)  # in nm
+                    r0_scaling = (r0_inf / r0)**(5./6.)
+                    infinite_screen *= r0_scaling
 
-        try:
-            for phase_size in phase_sizes:
-                for pixel_scale in pixel_scales:
-                    # Initialize accumulators
-                    inf_mean = 0
-                    inf_std = 0
-                    fft_mean = 0
-                    fft_std = 0
+                    # Create FFT phase screen with same parameters
+                    fft_screen = calc_phasescreen(L0, phase_size, pixel_scale,
+                                                seed=random_seed2 + i,
+                                                precision=1,
+                                                xp=np)
+                    fft_screen = fft_screen * 500 / (2 * np.pi)  # in nm
+                    r0_scaling = (pixel_scale / r0)**(5./6.)
+                    fft_screen *= r0_scaling
 
-                    for i in range(n_seeds):
-                        # Create infinite phase screen
-                        r0_inf = r0 #2 * pixel_scale
-                        ips = InfinitePhaseScreen(phase_size, pixel_scale, r0_inf, L0,
-                                                random_seed=random_seed1 + i,
-                                                target_device_idx=-1)
+                    # Accumulate statistics
+                    inf_mean += np.mean(infinite_screen) / n_seeds
+                    inf_std += np.std(infinite_screen) / n_seeds
+                    fft_mean += np.mean(fft_screen) / n_seeds
+                    fft_std += np.std(fft_screen) / n_seeds
 
-                        # Get initial phase screen
-                        infinite_screen = ips.scrn * 500 / (2 * np.pi)  # in nm
-                        r0_scaling = (r0_inf / r0)**(5./6.)
-                        infinite_screen *= r0_scaling
+                # Calculate ratio
+                std_ratio = inf_std / fft_std if fft_std != 0 else 0
 
-                        # Create FFT phase screen with same parameters
-                        fft_screen = calc_phasescreen(L0, phase_size, pixel_scale,
-                                                    seed=random_seed2 + i,
-                                                    precision=1,
-                                                    xp=np)
-                        fft_screen = fft_screen * 500 / (2 * np.pi)  # in nm
-                        r0_scaling = (pixel_scale / r0)**(5./6.)
-                        fft_screen *= r0_scaling
+                # Store results
+                result = {
+                    'phase_size': phase_size,
+                    'pixel_scale': pixel_scale,
+                    'inf_mean': inf_mean,
+                    'inf_std': inf_std,
+                    'fft_mean': fft_mean,
+                    'fft_std': fft_std,
+                    'std_ratio': std_ratio
+                }
+                results.append(result)
 
-                        # Accumulate statistics
-                        inf_mean += np.mean(infinite_screen) / n_seeds
-                        inf_std += np.std(infinite_screen) / n_seeds
-                        fft_mean += np.mean(fft_screen) / n_seeds
-                        fft_std += np.std(fft_screen) / n_seeds
+                # Print current result
+                if verbose:
+                    print(f"{phase_size:<12} {pixel_scale:<12} {inf_mean:<10.6f} {inf_std:<10.1f} {fft_mean:<10.6f} {fft_std:<10.1f} {std_ratio:<8.3f}")
 
-                    # Calculate ratio
-                    std_ratio = inf_std / fft_std if fft_std != 0 else 0
+        # Overall statistics
+        all_ratios = [r['std_ratio'] for r in results if r['std_ratio'] > 0]
+        min_ratio = np.min(all_ratios)
+        max_ratio = np.max(all_ratios)
 
-                    # Store results
-                    result = {
-                        'phase_size': phase_size,
-                        'pixel_scale': pixel_scale,
-                        'inf_mean': inf_mean,
-                        'inf_std': inf_std,
-                        'fft_mean': fft_mean,
-                        'fft_std': fft_std,
-                        'std_ratio': std_ratio
-                    }
-                    results.append(result)
+        failed_tests = []
+        for result in results:
+            phase_size = result['phase_size']
+            pixel_scale = result['pixel_scale']
+            inf_mean = result['inf_mean']
+            fft_mean = result['fft_mean']
+            std_ratio = result['std_ratio']
 
-                    # Print current result
-                    if verbose:
-                        print(f"{phase_size:<12} {pixel_scale:<12} {inf_mean:<10.6f} {inf_std:<10.1f} {fft_mean:<10.6f} {fft_std:<10.1f} {std_ratio:<8.3f}")
+            # Mean should be close to zero for both
+            try:
+                self.assertAlmostEqual(inf_mean, 0.0, places=2,
+                                    msg=f"Infinite screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
+                self.assertAlmostEqual(fft_mean, 0.0, places=2,
+                                    msg=f"FFT screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
+            except AssertionError as e:
+                failed_tests.append(f"Mean test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
 
-            test_completed.set()
+            # Standard deviations should be similar
+            min_ratio, max_ratio = 0.9, 1.5
 
-            # Overall statistics
-            all_ratios = [r['std_ratio'] for r in results if r['std_ratio'] > 0]
-            min_ratio = np.min(all_ratios)
-            max_ratio = np.max(all_ratios)
+            try:
+                self.assertTrue(min_ratio < std_ratio < max_ratio,
+                            f"Std ratio {std_ratio:.3f} should be in [{min_ratio}, {max_ratio}] for size={phase_size}, scale={pixel_scale}")
+            except AssertionError as e:
+                failed_tests.append(f"Std ratio test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
 
-            failed_tests = []
-            for result in results:
-                phase_size = result['phase_size']
-                pixel_scale = result['pixel_scale']
-                inf_mean = result['inf_mean']
-                fft_mean = result['fft_mean']
-                std_ratio = result['std_ratio']
-
-                # Mean should be close to zero for both
-                try:
-                    self.assertAlmostEqual(inf_mean, 0.0, places=2,
-                                        msg=f"Infinite screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
-                    self.assertAlmostEqual(fft_mean, 0.0, places=2,
-                                        msg=f"FFT screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
-                except AssertionError as e:
-                    failed_tests.append(f"Mean test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
-
-                # Standard deviations should be similar
-                min_ratio, max_ratio = 0.9, 1.5
-
-                try:
-                    self.assertTrue(min_ratio < std_ratio < max_ratio,
-                                f"Std ratio {std_ratio:.3f} should be in [{min_ratio}, {max_ratio}] for size={phase_size}, scale={pixel_scale}")
-                except AssertionError as e:
-                    failed_tests.append(f"Std ratio test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
-
-            if failed_tests:
-                print(f"\n{len(failed_tests)} test(s) failed:")
-                for failure in failed_tests[:10]:  # Show first 10 failures
-                    print(f"  - {failure}")
-                if len(failed_tests) > 10:
-                    print(f"  ... and {len(failed_tests) - 10} more")
-
-        finally:
-            timer.cancel()
+        if failed_tests:
+            print(f"\n{len(failed_tests)} test(s) failed:")
+            for failure in failed_tests[:10]:  # Show first 10 failures
+                print(f"  - {failure}")
+            if len(failed_tests) > 10:
+                print(f"  ... and {len(failed_tests) - 10} more")
 
     def test_reproducibility_with_same_seed(self):
         """Test that screens with same seed produce identical results"""
+
+        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         # Parameters
         mx_size = 64

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -8,7 +8,7 @@ from specula.lib.calc_phasescreen import calc_phasescreen
 
 from test.specula_testlib import cpu_and_gpu
 
-@unittest.skipIf(os.environ.get('CI') == 'true', "Disable for CI issues with Ubuntu and Python >=3.11")
+#@unittest.skipIf(os.environ.get('CI') == 'true', "Disable for CI issues with Ubuntu and Python >=3.11")
 class TestInfinitePhaseScreen(unittest.TestCase):
 
     @cpu_and_gpu

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -4,6 +4,7 @@ import specula
 specula.init(-1,precision=0)  # Default target device
 
 from specula import np
+from specula.lib.calc_phasescreen import calc_phasescreen
 
 @unittest.skipIf(os.environ.get('CI') == 'true', "Debugging CI issues")
 class TestInfinitePhaseScreen(unittest.TestCase):
@@ -41,7 +42,6 @@ class TestInfinitePhaseScreen(unittest.TestCase):
         """Compare statistics between InfinitePhaseScreen and calc_phasescreen (FFT method)
         across multiple combinations of phase_size and pixel_scale"""
 
-        from specula.lib.calc_phasescreen import calc_phasescreen
         from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         verbose = False

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -5,14 +5,13 @@ specula.init(-1,precision=0)  # Default target device
 
 from specula import np
 from specula.lib.calc_phasescreen import calc_phasescreen
-
-@unittest.skipIf(os.environ.get('CI') == 'true', "Debugging CI issues")
+from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
+        
+#@unittest.skipIf(os.environ.get('CI') == 'true', "Debugging CI issues")
 class TestInfinitePhaseScreen(unittest.TestCase):
 
     def test_phase_covariance_matches_theory(self):
         """Test that the phase covariance function matches theoretical values"""
-
-        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         # Parameters
         mx_size = 512
@@ -41,8 +40,6 @@ class TestInfinitePhaseScreen(unittest.TestCase):
     def test_infinite_vs_fft_phase_screen_statistics(self):
         """Compare statistics between InfinitePhaseScreen and calc_phasescreen (FFT method)
         across multiple combinations of phase_size and pixel_scale"""
-
-        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         verbose = False
 
@@ -165,8 +162,6 @@ class TestInfinitePhaseScreen(unittest.TestCase):
 
     def test_reproducibility_with_same_seed(self):
         """Test that screens with same seed produce identical results"""
-
-        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         # Parameters
         mx_size = 64

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -1,17 +1,22 @@
 import unittest
 import os
 import specula
-specula.init(-1,precision=0)  # Default target device
+specula.init(0)  # Default target device
 
-from specula import np
+from specula import np, cpuArray
 from specula.lib.calc_phasescreen import calc_phasescreen
-from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
-        
-#@unittest.skipIf(os.environ.get('CI') == 'true', "Debugging CI issues")
+
+from test.specula_testlib import cpu_and_gpu
+
+@unittest.skipIf(os.environ.get('CI') == 'true', "Disable for CI issues with Ubuntu and Python >=3.11")
 class TestInfinitePhaseScreen(unittest.TestCase):
 
-    def test_phase_covariance_matches_theory(self):
+    @cpu_and_gpu
+    def test_phase_covariance_matches_theory(self, target_device_idx, xp):
         """Test that the phase covariance function matches theoretical values"""
+
+        # moved here to avoid CI issues
+        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         # Parameters
         mx_size = 512
@@ -23,23 +28,27 @@ class TestInfinitePhaseScreen(unittest.TestCase):
         # Create infinite phase screen
         ips = InfinitePhaseScreen(mx_size, pixel_scale, r0, L0,
                                  random_seed=random_seed,
-                                 target_device_idx=-1)
+                                 target_device_idx=target_device_idx)
 
         # Test covariance function at different separations
-        separations = np.array([0.1, 0.5, 1.0, 2.0, 5.0, 10.0])  # meters
-        cov_values = ips.phase_covariance(separations, r0, L0)
+        separations = xp.array([0.1, 0.5, 1.0, 2.0, 5.0, 10.0])  # meters
+        cov_values = cpuArray(ips.phase_covariance(separations, r0, L0))
 
         # Basic sanity checks
         self.assertTrue(all(cov_values >= 0), "Covariance values should be non-negative")
         self.assertTrue(cov_values[0] > cov_values[-1], "Covariance should decrease with separation")
 
         # Check that covariance at zero separation is finite and positive
-        cov_zero = ips.phase_covariance(np.array([1e-6]), r0, L0)[0]
+        cov_zero = cpuArray(ips.phase_covariance(xp.array([1e-6]), r0, L0)[0])
         self.assertTrue(cov_zero > 0, "Covariance at zero separation should be positive")
 
-    def test_infinite_vs_fft_phase_screen_statistics(self):
+    @cpu_and_gpu
+    def test_infinite_vs_fft_phase_screen_statistics(self, target_device_idx, xp):
         """Compare statistics between InfinitePhaseScreen and calc_phasescreen (FFT method)
         across multiple combinations of phase_size and pixel_scale"""
+
+        # moved here to avoid CI issues
+        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         verbose = False
 
@@ -81,10 +90,10 @@ class TestInfinitePhaseScreen(unittest.TestCase):
                     r0_inf = r0 #2 * pixel_scale
                     ips = InfinitePhaseScreen(phase_size, pixel_scale, r0_inf, L0,
                                             random_seed=random_seed1 + i,
-                                            target_device_idx=-1)
+                                            target_device_idx=target_device_idx)
 
                     # Get initial phase screen
-                    infinite_screen = ips.scrn * 500 / (2 * np.pi)  # in nm
+                    infinite_screen = cpuArray(ips.scrn) * 500 / (2 * np.pi)  # in nm
                     r0_scaling = (r0_inf / r0)**(5./6.)
                     infinite_screen *= r0_scaling
 
@@ -92,8 +101,8 @@ class TestInfinitePhaseScreen(unittest.TestCase):
                     fft_screen = calc_phasescreen(L0, phase_size, pixel_scale,
                                                 seed=random_seed2 + i,
                                                 precision=1,
-                                                xp=np)
-                    fft_screen = fft_screen * 500 / (2 * np.pi)  # in nm
+                                                xp=xp)
+                    fft_screen = cpuArray(fft_screen) * 500 / (2 * np.pi)  # in nm
                     r0_scaling = (pixel_scale / r0)**(5./6.)
                     fft_screen *= r0_scaling
 
@@ -160,8 +169,12 @@ class TestInfinitePhaseScreen(unittest.TestCase):
             if len(failed_tests) > 10:
                 print(f"  ... and {len(failed_tests) - 10} more")
 
-    def test_reproducibility_with_same_seed(self):
+    @cpu_and_gpu
+    def test_reproducibility_with_same_seed(self, target_device_idx, xp):
         """Test that screens with same seed produce identical results"""
+
+        # moved here to avoid CI issues
+        from specula.data_objects.infinite_phase_screen import InfinitePhaseScreen
 
         # Parameters
         mx_size = 64
@@ -173,15 +186,15 @@ class TestInfinitePhaseScreen(unittest.TestCase):
         # Create two identical screens
         ips1 = InfinitePhaseScreen(mx_size, pixel_scale, r0, L0,
                                   random_seed=random_seed,
-                                  target_device_idx=-1)
+                                  target_device_idx=target_device_idx)
 
         ips2 = InfinitePhaseScreen(mx_size, pixel_scale, r0, L0,
                                   random_seed=random_seed,
-                                  target_device_idx=-1)
+                                  target_device_idx=target_device_idx)
 
         # Get screens
-        screen1 = ips1.scrn
-        screen2 = ips2.scrn
+        screen1 = cpuArray(ips1.scrn)
+        screen2 = cpuArray(ips2.scrn)
 
         # Should be identical
         np.testing.assert_array_equal(screen1, screen2,

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -71,7 +71,7 @@ class TestInfinitePhaseScreen(unittest.TestCase):
         # Store all results for summary
         results = []
 
-        if verbose:
+        if verbose:  # pragma: no cover
             print("\nTesting InfinitePhaseScreen vs FFT phase screen statistics")
             print("=" * 76)
             print(f"{'Phase Size':<12} {'Pixel Scale':<12} {'Inf Mean':<10} {'Inf Std':<10} {'FFT Mean':<10} {'FFT Std':<10} {'Ratio':<8}")
@@ -128,7 +128,7 @@ class TestInfinitePhaseScreen(unittest.TestCase):
                 results.append(result)
 
                 # Print current result
-                if verbose:
+                if verbose:  # pragma: no cover
                     print(f"{phase_size:<12} {pixel_scale:<12} {inf_mean:<10.6f} {inf_std:<10.1f} {fft_mean:<10.6f} {fft_std:<10.1f} {std_ratio:<8.3f}")
 
         # Overall statistics

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -1,4 +1,6 @@
 import unittest
+import os
+import signal
 import specula
 specula.init(-1,precision=1)  # Default target device
 
@@ -46,11 +48,19 @@ class TestInfinitePhaseScreen(unittest.TestCase):
         L0 = 25.0  # meters
         random_seed1 = 42
         random_seed2 = 1042
-        n_seeds = 5
+        n_seeds = 3
 
         # Test parameter combinations
-        phase_sizes = [512]
-        pixel_scales = [0.5, 0.05]
+        if os.environ.get('CI') == 'true':
+            phase_sizes = [128]
+            pixel_scales = [0.5]
+            n_seeds = 5
+            timeout = 60
+        else:
+            phase_sizes = [512]
+            pixel_scales = [0.5, 0.05]
+            n_seeds = 10
+            timeout = 60
 
         # Store all results for summary
         results = []
@@ -61,97 +71,107 @@ class TestInfinitePhaseScreen(unittest.TestCase):
             print(f"{'Phase Size':<12} {'Pixel Scale':<12} {'Inf Mean':<10} {'Inf Std':<10} {'FFT Mean':<10} {'FFT Std':<10} {'Ratio':<8}")
             print("-" * 76)
 
-        for phase_size in phase_sizes:
-            for pixel_scale in pixel_scales:
-                # Initialize accumulators
-                inf_mean = 0
-                inf_std = 0
-                fft_mean = 0
-                fft_std = 0
+        def timeout_handler(signum, frame):
+            raise TimeoutError("Test timeout exceeded")
 
-                for i in range(n_seeds):
-                    # Create infinite phase screen
-                    r0_inf = r0 #2 * pixel_scale
-                    ips = InfinitePhaseScreen(phase_size, pixel_scale, r0_inf, L0,
-                                            random_seed=random_seed1 + i,
-                                            target_device_idx=-1)
+        signal.signal(signal.SIGALRM, timeout_handler)
+        signal.alarm(timeout)
 
-                    # Get initial phase screen
-                    infinite_screen = ips.scrn * 500 / (2 * np.pi)  # in nm
-                    r0_scaling = (r0_inf / r0)**(5./6.)
-                    infinite_screen *= r0_scaling
+        try:
+            for phase_size in phase_sizes:
+                for pixel_scale in pixel_scales:
+                    # Initialize accumulators
+                    inf_mean = 0
+                    inf_std = 0
+                    fft_mean = 0
+                    fft_std = 0
 
-                    # Create FFT phase screen with same parameters
-                    fft_screen = calc_phasescreen(L0, phase_size, pixel_scale,
-                                                seed=random_seed2 + i,
-                                                precision=1,
-                                                xp=np)
-                    fft_screen = fft_screen * 500 / (2 * np.pi)  # in nm
-                    r0_scaling = (pixel_scale / r0)**(5./6.)
-                    fft_screen *= r0_scaling
+                    for i in range(n_seeds):
+                        # Create infinite phase screen
+                        r0_inf = r0 #2 * pixel_scale
+                        ips = InfinitePhaseScreen(phase_size, pixel_scale, r0_inf, L0,
+                                                random_seed=random_seed1 + i,
+                                                target_device_idx=-1)
 
-                    # Accumulate statistics
-                    inf_mean += np.mean(infinite_screen) / n_seeds
-                    inf_std += np.std(infinite_screen) / n_seeds
-                    fft_mean += np.mean(fft_screen) / n_seeds
-                    fft_std += np.std(fft_screen) / n_seeds
+                        # Get initial phase screen
+                        infinite_screen = ips.scrn * 500 / (2 * np.pi)  # in nm
+                        r0_scaling = (r0_inf / r0)**(5./6.)
+                        infinite_screen *= r0_scaling
 
-                # Calculate ratio
-                std_ratio = inf_std / fft_std if fft_std != 0 else 0
+                        # Create FFT phase screen with same parameters
+                        fft_screen = calc_phasescreen(L0, phase_size, pixel_scale,
+                                                    seed=random_seed2 + i,
+                                                    precision=1,
+                                                    xp=np)
+                        fft_screen = fft_screen * 500 / (2 * np.pi)  # in nm
+                        r0_scaling = (pixel_scale / r0)**(5./6.)
+                        fft_screen *= r0_scaling
 
-                # Store results
-                result = {
-                    'phase_size': phase_size,
-                    'pixel_scale': pixel_scale,
-                    'inf_mean': inf_mean,
-                    'inf_std': inf_std,
-                    'fft_mean': fft_mean,
-                    'fft_std': fft_std,
-                    'std_ratio': std_ratio
-                }
-                results.append(result)
+                        # Accumulate statistics
+                        inf_mean += np.mean(infinite_screen) / n_seeds
+                        inf_std += np.std(infinite_screen) / n_seeds
+                        fft_mean += np.mean(fft_screen) / n_seeds
+                        fft_std += np.std(fft_screen) / n_seeds
 
-                # Print current result
-                if verbose:
-                    print(f"{phase_size:<12} {pixel_scale:<12} {inf_mean:<10.6f} {inf_std:<10.1f} {fft_mean:<10.6f} {fft_std:<10.1f} {std_ratio:<8.3f}")
+                    # Calculate ratio
+                    std_ratio = inf_std / fft_std if fft_std != 0 else 0
 
-        # Overall statistics
-        all_ratios = [r['std_ratio'] for r in results if r['std_ratio'] > 0]
-        min_ratio = np.min(all_ratios)
-        max_ratio = np.max(all_ratios)
+                    # Store results
+                    result = {
+                        'phase_size': phase_size,
+                        'pixel_scale': pixel_scale,
+                        'inf_mean': inf_mean,
+                        'inf_std': inf_std,
+                        'fft_mean': fft_mean,
+                        'fft_std': fft_std,
+                        'std_ratio': std_ratio
+                    }
+                    results.append(result)
 
-        failed_tests = []
-        for result in results:
-            phase_size = result['phase_size']
-            pixel_scale = result['pixel_scale']
-            inf_mean = result['inf_mean']
-            fft_mean = result['fft_mean']
-            std_ratio = result['std_ratio']
+                    # Print current result
+                    if verbose:
+                        print(f"{phase_size:<12} {pixel_scale:<12} {inf_mean:<10.6f} {inf_std:<10.1f} {fft_mean:<10.6f} {fft_std:<10.1f} {std_ratio:<8.3f}")
 
-            # Mean should be close to zero for both
-            try:
-                self.assertAlmostEqual(inf_mean, 0.0, places=2,
-                                    msg=f"Infinite screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
-                self.assertAlmostEqual(fft_mean, 0.0, places=2,
-                                    msg=f"FFT screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
-            except AssertionError as e:
-                failed_tests.append(f"Mean test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
+            # Overall statistics
+            all_ratios = [r['std_ratio'] for r in results if r['std_ratio'] > 0]
+            min_ratio = np.min(all_ratios)
+            max_ratio = np.max(all_ratios)
 
-            # Standard deviations should be similar
-            min_ratio, max_ratio = 0.9, 1.5
+            failed_tests = []
+            for result in results:
+                phase_size = result['phase_size']
+                pixel_scale = result['pixel_scale']
+                inf_mean = result['inf_mean']
+                fft_mean = result['fft_mean']
+                std_ratio = result['std_ratio']
 
-            try:
-                self.assertTrue(min_ratio < std_ratio < max_ratio,
-                            f"Std ratio {std_ratio:.3f} should be in [{min_ratio}, {max_ratio}] for size={phase_size}, scale={pixel_scale}")
-            except AssertionError as e:
-                failed_tests.append(f"Std ratio test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
+                # Mean should be close to zero for both
+                try:
+                    self.assertAlmostEqual(inf_mean, 0.0, places=2,
+                                        msg=f"Infinite screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
+                    self.assertAlmostEqual(fft_mean, 0.0, places=2,
+                                        msg=f"FFT screen mean should be near zero (size={phase_size}, scale={pixel_scale})")
+                except AssertionError as e:
+                    failed_tests.append(f"Mean test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
 
-        if failed_tests:
-            print(f"\n{len(failed_tests)} test(s) failed:")
-            for failure in failed_tests[:10]:  # Show first 10 failures
-                print(f"  - {failure}")
-            if len(failed_tests) > 10:
-                print(f"  ... and {len(failed_tests) - 10} more")
+                # Standard deviations should be similar
+                min_ratio, max_ratio = 0.9, 1.5
+
+                try:
+                    self.assertTrue(min_ratio < std_ratio < max_ratio,
+                                f"Std ratio {std_ratio:.3f} should be in [{min_ratio}, {max_ratio}] for size={phase_size}, scale={pixel_scale}")
+                except AssertionError as e:
+                    failed_tests.append(f"Std ratio test failed for size={phase_size}, scale={pixel_scale}: {str(e)}")
+
+            if failed_tests:
+                print(f"\n{len(failed_tests)} test(s) failed:")
+                for failure in failed_tests[:10]:  # Show first 10 failures
+                    print(f"  - {failure}")
+                if len(failed_tests) > 10:
+                    print(f"  ... and {len(failed_tests) - 10} more")
+
+        finally:
+            signal.alarm(0)
 
     def test_reproducibility_with_same_seed(self):
         """Test that screens with same seed produce identical results"""

--- a/test/test_infinite_phase_screen.py
+++ b/test/test_infinite_phase_screen.py
@@ -8,7 +8,7 @@ from specula.lib.calc_phasescreen import calc_phasescreen
 
 from test.specula_testlib import cpu_and_gpu
 
-#@unittest.skipIf(os.environ.get('CI') == 'true', "Disable for CI issues with Ubuntu and Python >=3.11")
+@unittest.skipIf(os.environ.get('CI') == 'true', "Disable for CI issues with Ubuntu and Python >=3.11")
 class TestInfinitePhaseScreen(unittest.TestCase):
 
     @cpu_and_gpu


### PR DESCRIPTION
test_infinite_phase_screen.py cannot be not properly executed on Ubuntu with Python >= 3.11 on GitHub (on gandalf, debian 6.1, and luthien, ubuntu 20.04, with 3.11 it works properly), so it has been disable on CI: it hangs until the GitHub timeout of several hours is reached.
After several tests I found that apparently the issue is on the import of InfinitePhaseScreen.