### PR TITLE
Overwrite fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ main/scao/output/*
 # Nsys profiler repots
 *.nsys-rep
 
+.DS_Store

--- a/specula/data_objects/m2c.py
+++ b/specula/data_objects/m2c.py
@@ -75,10 +75,10 @@ class M2C(BaseDataObj):
         hdr['VERSION'] = 1
         return hdr
 
-    def save(self, filename):
+    def save(self, filename, overwrite:bool=False):
         """Saves the M2C to a file."""
         hdr = self.get_fits_header()
-        fits.writeto(filename, np.zeros(2), hdr)
+        fits.writeto(filename, np.zeros(2), hdr, overwrite=overwrite)
         fits.append(filename, cpuArray(self.m2c))
 
     @staticmethod

--- a/specula/processing_objects/sn_calibrator.py
+++ b/specula/processing_objects/sn_calibrator.py
@@ -35,7 +35,7 @@ class SnCalibrator(BaseProcessingObj):
             self.slopes.slopes += self.local_inputs['in_slopes'].slopes.copy()
         self._n_iter += 1
 
-    def finalize(self):
+    def finalize(self,overwrite:bool=False):
         # n_iter is used to normalize a slope null computed as average of several slopes
         self.slopes.slopes /= self._n_iter
         filename = self._filename
@@ -44,4 +44,4 @@ class SnCalibrator(BaseProcessingObj):
         file_path = os.path.join(self._data_dir, filename)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
-        self.slopes.save(os.path.join(self._data_dir, filename))
+        self.slopes.save(os.path.join(self._data_dir, filename),overwrite=overwrite)

--- a/specula/processing_objects/sn_calibrator.py
+++ b/specula/processing_objects/sn_calibrator.py
@@ -29,6 +29,12 @@ class SnCalibrator(BaseProcessingObj):
         self._n_iter = 0
         self.inputs['in_slopes'] = InputValue(type=Slopes)
 
+        self.sn_path = os.path.join(self._data_dir, self._filename)
+        if not self.sn_path.endswith('.fits'):
+            self.sn_path += '.fits'
+        if os.path.exists(self.sn_path) and not self.overwrite:
+            raise FileExistsError(f'Slope null file {self.sn_path} already exists, please remove it')
+
     def trigger_code(self):
         if self.slopes is None:
             self.slopes = Slopes(slopes=self.local_inputs['in_slopes'].slopes.copy(), target_device_idx=self.target_device_idx)

--- a/specula/processing_objects/sn_calibrator.py
+++ b/specula/processing_objects/sn_calibrator.py
@@ -44,5 +44,4 @@ class SnCalibrator(BaseProcessingObj):
             filename += '.fits'
         file_path = os.path.join(self._data_dir, filename)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
-
-        self.slopes.save(os.path.join(self._data_dir, filename),overwrite=self.overwrite)
+        self.slopes.save(file_path,overwrite=self.overwrite)

--- a/specula/processing_objects/sn_calibrator.py
+++ b/specula/processing_objects/sn_calibrator.py
@@ -9,12 +9,14 @@ class SnCalibrator(BaseProcessingObj):
     def __init__(self,
                  data_dir: str,         # Set by main simul object
                  output_tag: str = None,
+                 overwrite: bool = False,
                  tag_template: str = None,
                  target_device_idx: int = None,
                  precision: int = None
                 ):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
         self._data_dir = data_dir
+        self.overwrite = overwrite
 
         if tag_template is None and (output_tag is None or output_tag == 'auto'):
             raise ValueError('At least one of tag_template and output_tag must be set')
@@ -23,7 +25,6 @@ class SnCalibrator(BaseProcessingObj):
             self._filename = tag_template
         else:
             self._filename = output_tag
-
         self.slopes = None
         self._n_iter = 0
         self.inputs['in_slopes'] = InputValue(type=Slopes)
@@ -35,7 +36,7 @@ class SnCalibrator(BaseProcessingObj):
             self.slopes.slopes += self.local_inputs['in_slopes'].slopes.copy()
         self._n_iter += 1
 
-    def finalize(self,overwrite:bool=False):
+    def finalize(self):
         # n_iter is used to normalize a slope null computed as average of several slopes
         self.slopes.slopes /= self._n_iter
         filename = self._filename
@@ -44,4 +45,4 @@ class SnCalibrator(BaseProcessingObj):
         file_path = os.path.join(self._data_dir, filename)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
-        self.slopes.save(os.path.join(self._data_dir, filename),overwrite=overwrite)
+        self.slopes.save(os.path.join(self._data_dir, filename),overwrite=self.overwrite)

--- a/test/test_m2c.py
+++ b/test/test_m2c.py
@@ -12,6 +12,16 @@ class TestM2C(unittest.TestCase):
     def setUp(self):
         self.shape = (6, 4)  # 6 actuators × 4 modes
 
+    def test_existing_m2c_file_with_overwrite(self):
+        """Test that overwrite=True allows overwriting existing m2c files"""
+        m2c_tag = 'test_m2c_overwrite'
+        m2c_filename = f'{m2c_tag}.fits'
+        m2c_path = os.path.join(tempfile.mkdtemp(), m2c_filename)
+        with open(m2c_path, 'w') as f:
+            f.write('')
+        obj = M2C(m2c=np.random.rand(*self.shape))
+        obj.save(m2c_filename,overwrite=True)
+
     @cpu_and_gpu
     def test_initialization_and_get_value(self, target_device_idx, xp):
         data = xp.random.rand(*self.shape).astype(xp.float32)

--- a/test/test_sn_calibrator.py
+++ b/test/test_sn_calibrator.py
@@ -31,7 +31,8 @@ class TestImRecCalibrator(unittest.TestCase):
             f.write('')
 
         with self.assertRaises(FileExistsError):
-            _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
+            obj = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
+            obj.slopes.save(sn_path,obj.overwrite)
  
     def test_existing_sn_file_with_overwrite(self):
         """Test that overwrite=True allows overwriting existing files"""
@@ -44,4 +45,5 @@ class TestImRecCalibrator(unittest.TestCase):
             f.write('')
 
         # Should not raise
-        _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag, overwrite=True)
+        obj = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
+        obj.slopes.save(sn_path,obj.overwrite)

--- a/test/test_sn_calibrator.py
+++ b/test/test_sn_calibrator.py
@@ -1,0 +1,47 @@
+import specula
+specula.init(0)  # Default target device
+
+import os
+import tempfile
+import unittest
+import shutil
+
+from specula.processing_objects.sn_calibrator import SnCalibrator
+
+
+class TestImRecCalibrator(unittest.TestCase):
+
+    def setUp(self):
+        """Create unique temporary directory for each test"""
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up temporary files"""
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def test_existing_sn_file_is_detected(self):
+        """Test that ImCalibrator detects existing IM files"""
+        sn_tag = 'test_im'
+        sn_filename = f'{sn_tag}.fits'
+        sn_path = os.path.join(self.test_dir, sn_filename)
+
+        # Create empty file
+        with open(sn_path, 'w') as f:
+            f.write('')
+
+        with self.assertRaises(FileExistsError):
+            _ = SnCalibrator(data_dir=self.test_dir, sn_tag=sn_tag)
+ 
+    def test_existing_sn_file_with_overwrite(self):
+        """Test that overwrite=True allows overwriting existing files"""
+        sn_tag = 'test_sn_overwrite'
+        sn_filename = f'{sn_tag}.fits'
+        sn_path = os.path.join(self.test_dir, sn_filename)
+
+        # Create empty file
+        with open(sn_path, 'w') as f:
+            f.write('')
+
+        # Should not raise
+        _ = SnCalibrator(data_dir=self.test_dir, sn_tag=sn_tag, overwrite=True)

--- a/test/test_sn_calibrator.py
+++ b/test/test_sn_calibrator.py
@@ -31,7 +31,7 @@ class TestImRecCalibrator(unittest.TestCase):
             f.write('')
 
         with self.assertRaises(FileExistsError):
-            _ = SnCalibrator(data_dir=self.test_dir, sn_tag=sn_tag)
+            _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
  
     def test_existing_sn_file_with_overwrite(self):
         """Test that overwrite=True allows overwriting existing files"""
@@ -44,4 +44,4 @@ class TestImRecCalibrator(unittest.TestCase):
             f.write('')
 
         # Should not raise
-        _ = SnCalibrator(data_dir=self.test_dir, sn_tag=sn_tag, overwrite=True)
+        _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag, overwrite=True)

--- a/test/test_sn_calibrator.py
+++ b/test/test_sn_calibrator.py
@@ -23,7 +23,7 @@ class TestImRecCalibrator(unittest.TestCase):
     def test_existing_sn_file_is_detected(self):
         """Test that ImCalibrator detects existing IM files"""
         sn_tag = 'test_im'
-        sn_filename = f'{sn_tag}.fits'
+        sn_filename = f'{sn_tag}.fits' 
         sn_path = os.path.join(self.test_dir, sn_filename)
 
         # Create empty file
@@ -31,8 +31,7 @@ class TestImRecCalibrator(unittest.TestCase):
             f.write('')
 
         with self.assertRaises(FileExistsError):
-            obj = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
-            obj.slopes.save(sn_path,obj.overwrite)
+            _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
  
     def test_existing_sn_file_with_overwrite(self):
         """Test that overwrite=True allows overwriting existing files"""
@@ -45,5 +44,4 @@ class TestImRecCalibrator(unittest.TestCase):
             f.write('')
 
         # Should not raise
-        obj = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
-        obj.slopes.save(sn_path,obj.overwrite)
+        _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)

--- a/test/test_sn_calibrator.py
+++ b/test/test_sn_calibrator.py
@@ -44,4 +44,4 @@ class TestImRecCalibrator(unittest.TestCase):
             f.write('')
 
         # Should not raise
-        _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag)
+        _ = SnCalibrator(data_dir=self.test_dir, output_tag=sn_tag, overwrite=True)

--- a/test/test_sn_calibrator.py
+++ b/test/test_sn_calibrator.py
@@ -9,7 +9,7 @@ import shutil
 from specula.processing_objects.sn_calibrator import SnCalibrator
 
 
-class TestImRecCalibrator(unittest.TestCase):
+class TestSnCalibrator(unittest.TestCase):
 
     def setUp(self):
         """Create unique temporary directory for each test"""


### PR DESCRIPTION
overwrite is now an attribute of the sn_calibrator base processing object. I have also added a test_sn_calibrator.py script, brutally copied from test_im_rec_calibrator.py with appropriate changes. I am ignorant in python and pytests, so let me know if I was supposed to do something different