### PR TITLE
(GA) Data Source fix, tests and fieldAnalyser documentation

### DIFF
--- a/docs/tutorials/field_analyser_tutorial.rst
+++ b/docs/tutorials/field_analyser_tutorial.rst
@@ -194,7 +194,15 @@ Below is an example script that loads the latest simulation output and computes 
     field_psf = psf_results['psf_list'][0]
 
     # Compute modal analysis
-    modal_results = analyser.compute_modal_analysis()
+    modal_results = analyser.compute_modal_analysis(
+        modal_params={              # Modal analysis parameters
+            'type_str': 'zernike',  # Zernike modes
+            'nmodes': 50,           # Number of modes
+            'obsratio': 0.0,        # Pupil obstruction ratio
+            'diaratio': 1.0,        # Pupil diameter ratio
+            'dorms': True           # Compute RMS and not standard deviation
+        }
+    )
     modes = modal_results['modal_coeffs'][0]
 
     # Compute phase cube (units: nm)
@@ -209,7 +217,7 @@ Below is an example script that loads the latest simulation output and computes 
 
 When you call `compute_field_psf()`, `FieldAnalyser`:
 
-1. Reads the saved DM commands from the DataStore files (e.g., `comm-control.out_comm.fits`)
+1. Reads the saved DM commands from the DataStore files (e.g., `comm.fits`)
 2. Uses `build_targeted_replay` to create a minimal replay configuration
 3. Creates a replay chain that includes:
    
@@ -270,14 +278,14 @@ You can use matplotlib to visualize the PSF, modal coefficients, or phase slices
 Step 5: Comparing with Simulation Outputs
 -----------------------------------------
 
-You can compare the results from `FieldAnalyser` with those saved during the simulation (e.g., `psf-psf.out_int_psf.fits`, `res_modes-modal_analysis.out_modes.fits`) to verify consistency.
+You can compare the results from `FieldAnalyser` with those saved during the simulation (e.g., `psf.fits`, `res_modes.fits`) to verify consistency.
 
 .. code-block:: python
 
     from astropy.io import fits
 
     # Load original PSF from simulation
-    with fits.open(os.path.join(latest_data_dir, 'psf-psf.out_int_psf.fits')) as hdul:
+    with fits.open(os.path.join(latest_data_dir, 'psf.fits')) as hdul:
         original_psf = hdul[0].data
     
     # Normalize for fair comparison

--- a/specula/processing_objects/data_source.py
+++ b/specula/processing_objects/data_source.py
@@ -24,7 +24,7 @@ class DataSource(BaseProcessingObj):
         self.headers = {}
         self.obj_type = {}
 
-        for aout in outputs:            
+        for aout in outputs:    
             self.loadFromFile(aout)
         for k in self.storage.keys():
             if self.obj_type[k] not in ['BaseValue', 'BaseDataObj']:
@@ -50,7 +50,7 @@ class DataSource(BaseProcessingObj):
         if 'hdr' in unserialized_data:
             self.headers[name] = unserialized_data['hdr']
             self.obj_type[name] = self.headers[name]['OBJ_TYPE']
-        
+
         self.storage[name] = { t:data[i] for i, t in enumerate(times.tolist())}
 
     def load_fits(self, name):
@@ -70,8 +70,11 @@ class DataSource(BaseProcessingObj):
         return h.shape if not dimensions else h.shape[dimensions]
 
     def trigger_code(self):
-        for k in self.storage.keys():            
-            self.outputs[k].set_value(self.outputs[k].xp.array(self.storage[k][self.current_time]))
-            self.outputs[k].generation_time = self.current_time
-
-        
+        for k, storage_dict in self.storage.items():
+            # Check if data exists for current time
+            if self.current_time in storage_dict:
+                self.outputs[k].set_value(self.outputs[k].xp.array(storage_dict[self.current_time]))
+                self.outputs[k].generation_time = self.current_time
+            else:
+                if self.verbose:
+                    print(f'Warning: No data for key {k} at time {self.current_time}')

--- a/specula/processing_objects/data_source.py
+++ b/specula/processing_objects/data_source.py
@@ -24,7 +24,7 @@ class DataSource(BaseProcessingObj):
         self.headers = {}
         self.obj_type = {}
 
-        for aout in outputs:    
+        for aout in outputs:
             self.loadFromFile(aout)
         for k in self.storage.keys():
             if self.obj_type[k] not in ['BaseValue', 'BaseDataObj']:


### PR DESCRIPTION
This fix is required to enable the fieldAnalyser to work when an integrated PSF or any other data that is not produced at each frame of the simulation is stored.

It should also fix the issue: https://github.com/ArcetriAdaptiveOptics/SPECULA/issues/389