### PR TITLE
Zernike fix

### DIFF
--- a/specula/processing_objects/modulated_pyramid.py
+++ b/specula/processing_objects/modulated_pyramid.py
@@ -265,7 +265,7 @@ class ModulatedPyramid(BaseProcessingObj):
         self.transmission = BaseValue(value=self.xp.zeros(1, dtype=self.dtype),
                                       target_device_idx=self.target_device_idx,
                                       precision=precision)        
-        self.flux_inside_ccd = BaseValue(value=self.xp.ones(1, dtype=self.dtype),
+        self.flux_frac_inside_ccd = BaseValue(value=self.xp.ones(1, dtype=self.dtype),
                                       target_device_idx=self.target_device_idx,
                                       precision=precision)
 
@@ -274,7 +274,7 @@ class ModulatedPyramid(BaseProcessingObj):
         self.outputs['out_psf_tot'] = self.psf_tot
         self.outputs['out_psf_bfm'] = self.psf_bfm
         self.outputs['out_transmission'] = self.transmission
-        self.outputs['out_flux_inside_detector'] = self.flux_inside_ccd
+        self.outputs['out_flux_frac_inside_detector'] = self.flux_frac_inside_ccd
 
         # Generate the geometric phase map of the pyramid faces
         self.pyr_tlt = self.get_pyr_tlt(fft_sampling, fft_padding)
@@ -617,11 +617,11 @@ class ModulatedPyramid(BaseProcessingObj):
         elif self.final_ccd_side < self.toccd_side:
             delta = (self.toccd_side - self.final_ccd_side) // 2
             self.out_i.i[:] = ccd_internal[delta:delta + self.final_ccd_side, delta:delta + self.final_ccd_side]
-            self.flux_inside_ccd.value[:] = self.xp.sum(self.out_i.i[:])/self.xp.sum(ccd_internal)
+            self.flux_frac_inside_ccd.value[:] = self.xp.sum(self.out_i.i[:])/self.xp.sum(ccd_internal)
         else:
             self.out_i.i[:] = ccd_internal
         
-        self.flux_inside_ccd.generation_time = self.current_time
+        self.flux_frac_inside_ccd.generation_time = self.current_time
         self.out_i.generation_time = self.current_time
         self.psf_tot.generation_time = self.current_time
         self.psf_bfm.generation_time = self.current_time

--- a/specula/processing_objects/modulated_pyramid.py
+++ b/specula/processing_objects/modulated_pyramid.py
@@ -264,6 +264,9 @@ class ModulatedPyramid(BaseProcessingObj):
                                  precision=precision)
         self.transmission = BaseValue(value=self.xp.zeros(1, dtype=self.dtype),
                                       target_device_idx=self.target_device_idx,
+                                      precision=precision)        
+        self.flux_inside_ccd = BaseValue(value=self.xp.ones(1, dtype=self.dtype),
+                                      target_device_idx=self.target_device_idx,
                                       precision=precision)
 
         self.inputs['in_ef'] = InputValue(type=ElectricField)
@@ -271,6 +274,7 @@ class ModulatedPyramid(BaseProcessingObj):
         self.outputs['out_psf_tot'] = self.psf_tot
         self.outputs['out_psf_bfm'] = self.psf_bfm
         self.outputs['out_transmission'] = self.transmission
+        self.outputs['out_flux_inside_detector'] = self.flux_inside_ccd
 
         # Generate the geometric phase map of the pyramid faces
         self.pyr_tlt = self.get_pyr_tlt(fft_sampling, fft_padding)
@@ -613,9 +617,11 @@ class ModulatedPyramid(BaseProcessingObj):
         elif self.final_ccd_side < self.toccd_side:
             delta = (self.toccd_side - self.final_ccd_side) // 2
             self.out_i.i[:] = ccd_internal[delta:delta + self.final_ccd_side, delta:delta + self.final_ccd_side]
+            self.flux_inside_ccd.value[:] = self.xp.sum(self.out_i.i[:])/self.xp.sum(ccd_internal)
         else:
             self.out_i.i[:] = ccd_internal
-
+        
+        self.flux_inside_ccd.generation_time = self.current_time
         self.out_i.generation_time = self.current_time
         self.psf_tot.generation_time = self.current_time
         self.psf_bfm.generation_time = self.current_time

--- a/specula/processing_objects/modulated_pyramid.py
+++ b/specula/processing_objects/modulated_pyramid.py
@@ -338,7 +338,7 @@ class ModulatedPyramid(BaseProcessingObj):
                              f" not enough to hold the pupil geometry."
                              f" Minimum allowed side is {min_ccd_side}")
 
-        internal_ccd_side = self.xp.around(fft_res * pup_diam / 2) * 2
+        internal_ccd_side = int(self.xp.around(fft_res * pup_diam / 2) * 2)
 
         # Theoretical fft resolution, and minimum fft resolution to hold the pupil geometry
         fft_res = internal_ccd_side / float(pup_diam)

--- a/specula/processing_objects/psf.py
+++ b/specula/processing_objects/psf.py
@@ -1,5 +1,6 @@
 
 from specula.lib.calc_psf import calc_psf, calc_psf_geometry
+from specula.lib.radial_profile import computeRadialProfile
 
 from specula.base_processing_obj import BaseProcessingObj
 from specula.base_value import BaseValue
@@ -145,3 +146,28 @@ class PSF(BaseProcessingObj):
         self.int_psf.generation_time = self.current_time
         self.int_sr.generation_time = self.current_time
         self.std_psf.generation_time = self.current_time
+
+        
+    def get_psf_profile(self, psf_std:bool=False, show:bool=False):
+        if psf_std is True:
+            psf = self.std_psf.value
+        else:
+            psf = self.int_psf.value
+        norm_psf = psf/self.xp.max(psf)
+        profile,pix_dist = computeRadialProfile(norm_psf, xp=self.xp, dtype=self.dtype)
+        radial_dist = pix_dist/self.nd
+        if show:
+            try:
+                import matplotlib.pyplot as plt
+                from specula import cpuArray
+                plt.figure()
+                plt.plot(cpuArray(radial_dist),cpuArray(profile))
+                plt.grid()
+                plt.yscale('log')
+                plt.xlabel(r'$\lambda/D$')
+                plt.ylabel('PSF contrast')
+                plt.show()
+            except:
+                print('Failed to import matplotlib for display')
+        return profile, radial_dist
+        

--- a/specula/processing_objects/zernike_sensor.py
+++ b/specula/processing_objects/zernike_sensor.py
@@ -14,14 +14,14 @@ class ZernikeSensor(ModulatedPyramid):
                  fov,
                  pup_diam,
                  output_resolution,
-                 spot_radius_lambda: float=1.0,  # Spot radius in λ/D units
-                 phase_shift: float = 3.141592653589793 / 2,  # π/2 phase shift
-                 fft_res: float = 8.0,
+                 spot_radius_lambda: float= 1.0,  # Spot radius in λ/D units
+                 phase_shift_pi: float = 0.5,  # π/2 phase shift
+                 fft_res: float = 4.0,
                  target_device_idx=None,
                  precision=None):
 
         self.spot_radius_lambda = spot_radius_lambda
-        self.phase_shift = phase_shift
+        self.phase_shift = phase_shift_pi
 
         # Force modulation to zero (no modulation for Zernike sensor)
         super().__init__(
@@ -33,19 +33,20 @@ class ZernikeSensor(ModulatedPyramid):
             mod_amp=0.0,
             mod_step=1,
             fft_res=fft_res,
-            pup_dist=1,
-            pup_margin=1,
-            min_pup_dist=1,
+            pup_dist=0,
+            pup_margin=0,
+            min_pup_dist=0,
             fov_errinf=0.1,
-            fov_errsup=0.5,
+            fov_errsup=10.0,
             target_device_idx=target_device_idx,
             precision=precision
-        )
+        )        
+
 
     def get_pyr_tlt(self, p, c):
         """
-        Creates a phase-shifting focal-plane spot of π/2.
-        This introduces a π/2 phase shift in a circular region
+        Creates a phase-shifting focal-plane spot of self.phase_delay π.
+        This introduces a self.phase_delay π phase shift in a circular region
         centered on the focal plane, replacing the traditional pyramid structure.
         
         Args:
@@ -53,7 +54,7 @@ class ZernikeSensor(ModulatedPyramid):
             c: FFT padding parameter
             
         Returns:
-            phase_mask: 2D array with π/2 phase shift in central spot
+            phase_mask: 2D array with phase shift in central spot
         """
         A = int((p + c) // 2)
 
@@ -61,17 +62,17 @@ class ZernikeSensor(ModulatedPyramid):
         xx, yy = self.xp.mgrid[-A:A, -A:A].astype(self.dtype)
 
         # Convert radius from λ/D units to pixels
-        # In focal plane, 1 λ/D corresponds to fft_padding/fft_sampling pixels
+        # In focal plane, 1 λ/D corresponds to fft_totsize/fft_sampling pixels
         fft_sampling = p
         fft_padding = c
-        spot_radius_pixels = self.spot_radius_lambda * fft_padding/fft_sampling
+        spot_radius_pixels = self.spot_radius_lambda * (1+fft_padding/fft_sampling)
 
         # Calculate distance from center
-        rr = self.xp.sqrt(xx**2 + yy**2)
+        rr = self.xp.sqrt((xx+0.5)**2 + (yy+0.5)**2)
 
-        # Create phase mask: self.phase_shift (default π/2) inside circle, 0 outside
+        # Create phase mask: self.phase_shift
         phase_mask = self.xp.where(rr <= spot_radius_pixels,
-                                   self.phase_shift,
+                                   self.phase_shift/2, # phase is multiplied by 2π during super().__init__
                                    0.0)
 
         return phase_mask

--- a/specula/processing_objects/zernike_sensor.py
+++ b/specula/processing_objects/zernike_sensor.py
@@ -21,7 +21,7 @@ class ZernikeSensor(ModulatedPyramid):
                  precision=None):
 
         self.spot_radius_lambda = spot_radius_lambda
-        self.phase_shift = phase_shift_pi
+        self.phase_shift_pi = phase_shift_pi
 
         # Force modulation to zero (no modulation for Zernike sensor)
         super().__init__(
@@ -70,9 +70,9 @@ class ZernikeSensor(ModulatedPyramid):
         # Calculate distance from center
         rr = self.xp.sqrt((xx+0.5)**2 + (yy+0.5)**2)
 
-        # Create phase mask: self.phase_shift
+        # Create phase mask: self.phase_shift_pi
         phase_mask = self.xp.where(rr <= spot_radius_pixels,
-                                   self.phase_shift/2, # phase is multiplied by 2π during super().__init__
+                                   self.phase_shift_pi/2, # phase is multiplied by 2π during super().__init__
                                    0.0)
 
         return phase_mask


### PR DESCRIPTION
Debugging of the zernike_sensor.py class

Added the flux_inside_ccd attribute to the ModulatedPyramid class to account for the flux lost when using a detector smaller than fft_res x pup_diam 

Also added the get_psf_profile method to the PSF class, using the computeRadialProfile function