### PR TITLE
Rowcols

### DIFF
--- a/specula/data_objects/electric_field.py
+++ b/specula/data_objects/electric_field.py
@@ -54,8 +54,8 @@ class ElectricField(BaseDataObj):
         dimy = int(dimy)
         self.pixel_pitch = pixel_pitch
         self.S0 = S0
-        A = self.xp.ones((dimx, dimy), dtype=self.dtype)
-        phaseInNm = self.xp.zeros((dimx, dimy), dtype=self.dtype)
+        A = self.xp.ones((dimy, dimx), dtype=self.dtype)
+        phaseInNm = self.xp.zeros((dimy, dimx), dtype=self.dtype)
         self.field = self.xp.stack((A, phaseInNm))
     
     @property
@@ -114,7 +114,7 @@ class ElectricField(BaseDataObj):
         '''
         dimx = int(dimx)
         dimy = int(dimy)
-        self.field = self.xp.zeros((2, dimx, dimy), dtype=self.dtype)
+        self.field = self.xp.zeros((2, dimy, dimx), dtype=self.dtype)
         if pitch is not None:
             self.pixel_pitch = pitch
         self.reset()
@@ -284,8 +284,8 @@ class ElectricField(BaseDataObj):
         hdr = fits.Header()
         hdr['VERSION'] = 1
         hdr['OBJ_TYPE'] = 'ElectricField'
-        hdr['DIMX'] = self.field[0].shape[0]
-        hdr['DIMY'] = self.field[0].shape[1]
+        hdr['DIMX'] = self.field[0].shape[1]
+        hdr['DIMY'] = self.field[0].shape[0]
         hdr['PIXPITCH'] = self.pixel_pitch
         hdr['S0'] = self.S0
         return hdr

--- a/specula/data_objects/intensity.py
+++ b/specula/data_objects/intensity.py
@@ -17,7 +17,7 @@ class Intensity(BaseDataObj):
         Initialize an :class:`~specula.data_objects.intensity.Intensity` object.
         """
         super().__init__(target_device_idx=target_device_idx, precision=precision)
-        self.i = self.xp.zeros((dimx, dimy), dtype=self.dtype)
+        self.i = self.xp.zeros((dimy, dimx), dtype=self.dtype)
 
     def get_value(self):
         '''
@@ -41,8 +41,8 @@ class Intensity(BaseDataObj):
         hdr = fits.Header()
         hdr['VERSION'] = 1
         hdr['OBJ_TYPE'] = 'Intensity'
-        hdr['DIMX'] = self.i.shape[0]
-        hdr['DIMY'] = self.i.shape[1]
+        hdr['DIMX'] = self.i.shape[1]
+        hdr['DIMY'] = self.i.shape[0]
         return hdr
 
     def save(self, filename, overwrite=True):

--- a/specula/data_objects/layer.py
+++ b/specula/data_objects/layer.py
@@ -56,8 +56,8 @@ class Layer(ElectricField):
         hdr = fits.Header()
         hdr['VERSION'] = 1
         hdr['OBJ_TYPE'] = 'Layer'
-        hdr['DIMX'] = self.field[0].shape[0]
-        hdr['DIMY'] = self.field[0].shape[1]
+        hdr['DIMX'] = self.field[0].shape[1]
+        hdr['DIMY'] = self.field[0].shape[0]
         hdr['PIXPITCH'] = self.pixel_pitch
         hdr['HEIGHT'] = self.height
         hdr['SHIFTX'] = float(self.shiftXYinPixel[0])

--- a/specula/data_objects/lenslet.py
+++ b/specula/data_objects/lenslet.py
@@ -56,11 +56,11 @@ class Lenslet(BaseDataObj):
         raise NotImplementedError
 
     @property
-    def dimx(self):
+    def dimy(self):
         return len(self._lenses)
 
     @property
-    def dimy(self):
+    def dimx(self):
         return len(self._lenses[0]) if self._lenses else 0
 
     def get(self, x, y):

--- a/specula/data_objects/pixels.py
+++ b/specula/data_objects/pixels.py
@@ -102,8 +102,8 @@ class Pixels(BaseDataObj):
         hdr['BPP'] = self.bpp
         hdr['BYTESPP'] = self.bytespp
         hdr['SIGNED'] = self.signed
-        hdr['DIMX'] = self.pixels.shape[0]
-        hdr['DIMY'] = self.pixels.shape[1]
+        hdr['DIMX'] = self.pixels.shape[1]
+        hdr['DIMY'] = self.pixels.shape[0]
         return hdr
 
     def save(self, filename, overwrite=True):

--- a/specula/data_objects/pixels.py
+++ b/specula/data_objects/pixels.py
@@ -42,7 +42,7 @@ class Pixels(BaseDataObj):
 
         self.signed = signed
         self.type = self._get_type(bits, signed)
-        self.pixels = self.xp.zeros((dimx, dimy), dtype=self.dtype)
+        self.pixels = self.xp.zeros((dimy, dimx), dtype=self.dtype)
         self.bpp = bits
         self.bytespp = (bits + 7) // 8  # bits self.xp.arounded to the next multiple of 8
 

--- a/specula/processing_objects/ciao_ciao_sensor.py
+++ b/specula/processing_objects/ciao_ciao_sensor.py
@@ -160,7 +160,7 @@ class CiaoCiaoSensor(BaseProcessingObj):
         super().setup()
 
         in_ef = self.local_inputs['in_ef']
-        dimx, dimy = in_ef.size
+        dimy, dimx = in_ef.size
 
         self.ef_interpolator_in = EFInterpolator(
             in_ef=in_ef,
@@ -187,10 +187,10 @@ class CiaoCiaoSensor(BaseProcessingObj):
             precision=self.precision
         )
 
-        self._ef = self.xp.zeros((dimx, dimy), dtype=self.complex_dtype)
-        self._rot_ef = self.xp.zeros((dimx, dimy), dtype=self.complex_dtype)
-        self._interf_ef = self.xp.zeros((dimx, dimy), dtype=self.complex_dtype)
-        self._interf_i = self.xp.zeros((dimx, dimy), dtype=self.dtype)
+        self._ef = self.xp.zeros((dimy, dimx), dtype=self.complex_dtype)
+        self._rot_ef = self.xp.zeros((dimy, dimx), dtype=self.complex_dtype)
+        self._interf_ef = self.xp.zeros((dimy, dimx), dtype=self.complex_dtype)
+        self._interf_i = self.xp.zeros((dimy, dimx), dtype=self.dtype)
 
         tilt_phase_nm = self._build_tilt_phase_map_nm(in_ef)
         tilt_phase_rad = tilt_phase_nm * ((2 * self.xp.pi) / self.wavelength_in_nm)

--- a/specula/processing_objects/electric_field_reflection.py
+++ b/specula/processing_objects/electric_field_reflection.py
@@ -21,8 +21,8 @@ class ElectricFieldReflection(BaseProcessingObj):
         super().setup()
         in_ef = self.local_inputs['in_ef']
         self._out_ef.resize(
-            dimx=in_ef.A.shape[0],
-            dimy=in_ef.A.shape[1],
+            dimx=in_ef.A.shape[1],
+            dimy=in_ef.A.shape[0],
             pitch=in_ef.pixel_pitch,
         )
 

--- a/specula/processing_objects/phase_flattening.py
+++ b/specula/processing_objects/phase_flattening.py
@@ -33,8 +33,8 @@ class PhaseFlattening(BaseProcessingObj):
         in_ef = self.local_inputs['in_ef']
 
         self._out_ef.resize(
-            dimx=in_ef.A.shape[0],
-            dimy=in_ef.A.shape[1],
+            dimx=in_ef.A.shape[1],
+            dimy=in_ef.A.shape[0],
             pitch=in_ef.pixel_pitch,
         )
 

--- a/specula/processing_objects/sh.py
+++ b/specula/processing_objects/sh.py
@@ -364,11 +364,11 @@ class SH(BaseProcessingObj):
 
         self._cutpixels = int(np.round(fov_cut / fp4_pixel_pitch) / 2 * 2)
         self._cutsize = fft_size - self._cutpixels
-        self._psfimage = self._zeros_common((self._cutsize * self._lenslet.dimx,
-                                             self._cutsize * self._lenslet.dimy),
+        self._psfimage = self._zeros_common((self._cutsize * self._lenslet.dimy,
+                                             self._cutsize * self._lenslet.dimx),
                                             dtype=self.dtype)
         self._psf_reshaped_2d = self._zeros_common((self._cutsize,
-                                                    self._cutsize * self._lenslet.dimy),
+                                                    self._cutsize * self._lenslet.dimx),
                                                    dtype=self.dtype)
 
         # 1/2 Px tilt

--- a/specula/processing_objects/sh_subap_calibrator.py
+++ b/specula/processing_objects/sh_subap_calibrator.py
@@ -96,7 +96,7 @@ class ShSubapCalibrator(BaseProcessingObj):
                     mask_subap[int(self.xp.round(x[i, j] - np_sub / 2)):int(self.xp.round(x[i, j] + np_sub / 2)),
                         int(self.xp.round(y[i, j] - np_sub / 2)):int(self.xp.round(y[i, j] + np_sub / 2))] = 1
                     idxs[count] = self.xp.where(mask_subap == 1)
-                    map[count] = i * self._lenslet.dimx + j
+                    map[count] = j * self._lenslet.dimx + i
                     count += 1
 
         if count == 0:

--- a/specula/processing_objects/sh_subap_calibrator.py
+++ b/specula/processing_objects/sh_subap_calibrator.py
@@ -71,12 +71,12 @@ class ShSubapCalibrator(BaseProcessingObj):
 
         idxs = {}
         map = {}
-        spot_intensity = self.xp.zeros((self._lenslet.dimx, self._lenslet.dimy))
-        x = self.xp.zeros((self._lenslet.dimx, self._lenslet.dimy))
-        y = self.xp.zeros((self._lenslet.dimx, self._lenslet.dimy))
+        spot_intensity = self.xp.zeros((self._lenslet.dimy, self._lenslet.dimx))
+        x = self.xp.zeros((self._lenslet.dimy, self._lenslet.dimx))
+        y = self.xp.zeros((self._lenslet.dimy, self._lenslet.dimx))
 
-        for i in range(self._lenslet.dimx):
-            for j in range(self._lenslet.dimy):
+        for i in range(self._lenslet.dimy):
+            for j in range(self._lenslet.dimx):
                 lens = self._lenslet.get(i, j)
                 x[i, j] = np / 2.0 * (1 + lens[0])
                 y[i, j] = np / 2.0 * (1 + lens[1])
@@ -89,14 +89,14 @@ class ShSubapCalibrator(BaseProcessingObj):
                 spot_intensity[i, j] = self.xp.sum(image * mask_subap)
 
         count = 0
-        for i in range(self._lenslet.dimx):
-            for j in range(self._lenslet.dimy):
+        for i in range(self._lenslet.dimy):
+            for j in range(self._lenslet.dimx):
                 if spot_intensity[i, j] > energy_th * self.xp.max(spot_intensity):
                     mask_subap *= 0
                     mask_subap[int(self.xp.round(x[i, j] - np_sub / 2)):int(self.xp.round(x[i, j] + np_sub / 2)),
                         int(self.xp.round(y[i, j] - np_sub / 2)):int(self.xp.round(y[i, j] + np_sub / 2))] = 1
                     idxs[count] = self.xp.where(mask_subap == 1)
-                    map[count] = j * self._lenslet.dimx + i
+                    map[count] = i * self._lenslet.dimx + j
                     count += 1
 
         if count == 0:

--- a/test/test_ciao_ciao_sensor.py
+++ b/test/test_ciao_ciao_sensor.py
@@ -93,12 +93,11 @@ class TestCiaoCiaoSensor(unittest.TestCase):
         ef.generation_time = t
 
         wfs.inputs['in_ef'].set(ef)
-        wfs.setup()
 
-        assert wfs._ef.shape == (dimy, dimx)
-        assert wfs._rot_ef.shape == (dimy, dimx)
-        assert wfs._interf_ef.shape == (dimy, dimx)
-        assert wfs._interf_i.shape == (dimy, dimx)
+        # CiaoCiao requries a square input array
+        with self.assertRaises(ValueError):
+            wfs.setup()
+
 
     @cpu_and_gpu
     def test_channel_flux_unbalance(self, target_device_idx, xp):

--- a/test/test_ciao_ciao_sensor.py
+++ b/test/test_ciao_ciao_sensor.py
@@ -72,6 +72,35 @@ class TestCiaoCiaoSensor(unittest.TestCase):
         )
 
     @cpu_and_gpu
+    def test_ciaociao_shape(self, target_device_idx, xp):
+        t = 1
+        ref_S0 = 123.0
+        number_px = 48
+
+        wfs = CiaoCiaoSensor(
+            wavelengthInNm=750.0,
+            number_px=number_px,
+            diffRotAngleInDeg=180.0,
+            tiltInArcsec=(0.02, -0.01),
+            normalize_flux=True,
+            target_device_idx=target_device_idx
+        )
+
+        dimx = 10
+        dimy = 20
+
+        ef = ElectricField(dimx, dimy, 0.01, S0=ref_S0, target_device_idx=target_device_idx)
+        ef.generation_time = t
+
+        wfs.inputs['in_ef'].set(ef)
+        wfs.setup()
+
+        assert wfs._ef.shape == (dimy, dimx)
+        assert wfs._rot_ef.shape == (dimy, dimx)
+        assert wfs._interf_ef.shape == (dimy, dimx)
+        assert wfs._interf_i.shape == (dimy, dimx)
+
+    @cpu_and_gpu
     def test_channel_flux_unbalance(self, target_device_idx, xp):
         t = 1
         dim = 40

--- a/test/test_electric_field.py
+++ b/test/test_electric_field.py
@@ -31,6 +31,13 @@ class TestElectricField(unittest.TestCase):
         assert id_field_before == id_field_after
 
     @cpu_and_gpu
+    def test_ef_shape(self, target_device_idx, xp):
+        dimx = 10
+        dimy = 20
+        obj = ElectricField(dimx, dimy, 0.1, S0=1, target_device_idx=target_device_idx)
+        self.assertEqual(obj.A.shape, (dimy, dimx))
+
+    @cpu_and_gpu
     def test_set_value_does_not_reallocate(self, target_device_idx, xp):
 
         ef = ElectricField(10,10, 0.1, S0=1, target_device_idx=target_device_idx)
@@ -85,11 +92,13 @@ class TestElectricField(unittest.TestCase):
     @cpu_and_gpu
     def test_ef_reflection(self, target_device_idx, xp):
         pixel_pitch = 0.1
-        pixel_pupil = 10
-        ef1 = ElectricField(pixel_pupil, pixel_pupil, pixel_pitch, S0=1, target_device_idx=target_device_idx)
-        A1 = xp.ones((pixel_pupil, pixel_pupil))
-        ef1.A = A1
-        ef1.phaseInNm = 1 * xp.ones((pixel_pupil, pixel_pupil))
+
+        dimx = 10
+        dimy = 20
+
+        ef1 = ElectricField(dimx, dimy, pixel_pitch, S0=1, target_device_idx=target_device_idx)
+        ef1.A[:] = 1
+        ef1.phaseInNm[:] = 1
 
         ef_reflection = ElectricFieldReflection(
             target_device_idx=target_device_idx
@@ -109,6 +118,7 @@ class TestElectricField(unittest.TestCase):
 
         assert np.allclose(out_ef.A, ef1.A)
         assert np.allclose(out_ef.phaseInNm, -1*ef1.phaseInNm)
+        assert out_ef.A.shape == (dimy, dimx)
 
     @cpu_and_gpu
     def test_save_and_restore(self, target_device_idx, xp):
@@ -176,17 +186,18 @@ class TestElectricField(unittest.TestCase):
 
     @cpu_and_gpu
     def test_fits_header(self, target_device_idx, xp):
-        pixel_pupil = 10
+        dimx = 10
+        dimy = 20
         pixel_pitch = 0.1
         S0 = 1.23
-        ef = ElectricField(pixel_pupil, pixel_pupil, pixel_pitch, S0=S0, target_device_idx=target_device_idx)
+        ef = ElectricField(dimx, dimy, pixel_pitch, S0=S0, target_device_idx=target_device_idx)
 
         hdr = ef.get_fits_header()
 
         assert hdr['VERSION'] == 1
         assert hdr['OBJ_TYPE'] == 'ElectricField'
-        assert hdr['DIMX'] == pixel_pupil
-        assert hdr['DIMY'] == pixel_pupil
+        assert hdr['DIMX'] == dimx
+        assert hdr['DIMY'] == dimy
         assert hdr['PIXPITCH'] == pixel_pitch
         assert hdr['S0'] == S0        
         

--- a/test/test_intensity.py
+++ b/test/test_intensity.py
@@ -14,32 +14,33 @@ from test.specula_testlib import cpu_and_gpu
 
 class TestIntensity(unittest.TestCase):
     def setUp(self):
-        self.shape = (4, 5)
+        self.dimxy = (5, 4)
+        self.shape = (self.dimxy[1], self.dimxy[0])  # (dimy, dimx) for array shape
 
     @cpu_and_gpu
     def test_initialization_and_get_value(self, target_device_idx, xp):
-        obj = Intensity(*self.shape, target_device_idx=target_device_idx)
+        obj = Intensity(*self.dimxy, target_device_idx=target_device_idx)
         self.assertEqual(obj.i.shape, self.shape)
         np.testing.assert_array_equal(cpuArray(obj.get_value()), np.zeros(self.shape))
 
     @cpu_and_gpu
     def test_set_value(self, target_device_idx, xp):
-        obj = Intensity(*self.shape, target_device_idx=target_device_idx)
+        obj = Intensity(*self.dimxy, target_device_idx=target_device_idx)
         new_val = xp.random.rand(*self.shape).astype(xp.float32)
         obj.set_value(new_val)
         np.testing.assert_array_equal(cpuArray(obj.get_value()), cpuArray(new_val))
 
     @cpu_and_gpu
     def test_set_value_wrong_shape(self, target_device_idx, xp):
-        obj = Intensity(*self.shape, target_device_idx=target_device_idx)
+        obj = Intensity(*self.dimxy, target_device_idx=target_device_idx)
         wrong_shape = xp.random.rand(2, 2).astype(xp.float32)
         with self.assertRaises(AssertionError):
             obj.set_value(wrong_shape)
 
     @cpu_and_gpu
     def test_sum(self, target_device_idx, xp):
-        obj1 = Intensity(*self.shape, target_device_idx=target_device_idx)
-        obj2 = Intensity(*self.shape, target_device_idx=target_device_idx)
+        obj1 = Intensity(*self.dimxy, target_device_idx=target_device_idx)
+        obj2 = Intensity(*self.dimxy, target_device_idx=target_device_idx)
         obj1.set_value(xp.ones(self.shape, dtype=xp.float32))
         obj2.set_value(xp.ones(self.shape, dtype=xp.float32) * 2)
 
@@ -49,17 +50,17 @@ class TestIntensity(unittest.TestCase):
 
     @cpu_and_gpu
     def test_get_fits_header(self, target_device_idx, xp):
-        obj = Intensity(*self.shape, target_device_idx=target_device_idx)
+        obj = Intensity(*self.dimxy, target_device_idx=target_device_idx)
         hdr = obj.get_fits_header()
         self.assertIsInstance(hdr, fits.Header)
         self.assertEqual(hdr["VERSION"], 1)
         self.assertEqual(hdr["OBJ_TYPE"], "Intensity")
-        self.assertEqual(hdr["DIMX"], self.shape[0])
-        self.assertEqual(hdr["DIMY"], self.shape[1])
+        self.assertEqual(hdr["DIMX"], self.shape[1])
+        self.assertEqual(hdr["DIMY"], self.shape[0])
 
     @cpu_and_gpu
     def test_save_restore_roundtrip(self, target_device_idx, xp):
-        obj = Intensity(*self.shape, target_device_idx=target_device_idx)
+        obj = Intensity(*self.dimxy, target_device_idx=target_device_idx)
         data = xp.random.rand(*self.shape).astype(xp.float32)
         obj.set_value(data)
 
@@ -74,8 +75,8 @@ class TestIntensity(unittest.TestCase):
 
                 # Primary HDU: header only, no data
                 self.assertEqual(hdul[0].header["OBJ_TYPE"], "Intensity") # pylint: disable=no-member
-                self.assertEqual(hdul[0].header["DIMX"], self.shape[0])   # pylint: disable=no-member
-                self.assertEqual(hdul[0].header["DIMY"], self.shape[1])   # pylint: disable=no-member
+                self.assertEqual(hdul[0].header["DIMX"], self.shape[1])   # pylint: disable=no-member
+                self.assertEqual(hdul[0].header["DIMY"], self.shape[0])   # pylint: disable=no-member
                 self.assertIsNone(hdul[0].data)                           # pylint: disable=no-member
 
                 # Second HDU: intensity data
@@ -108,7 +109,7 @@ class TestIntensity(unittest.TestCase):
         hdr = fits.Header()
         hdr["VERSION"] = 1
         hdr["OBJ_TYPE"] = "Intensity"
-        hdr["DIMX"], hdr["DIMY"] = self.shape
+        hdr["DIMX"], hdr["DIMY"] = self.dimxy
         intensity = Intensity.from_header(hdr, target_device_idx=target_device_idx)
         self.assertEqual(intensity.i.shape, self.shape)
 
@@ -119,7 +120,7 @@ class TestIntensity(unittest.TestCase):
 
     @cpu_and_gpu
     def test_array_for_display(self, target_device_idx, xp):
-        obj = Intensity(*self.shape, target_device_idx=target_device_idx)
+        obj = Intensity(*self.dimxy, target_device_idx=target_device_idx)
         data = xp.random.rand(*self.shape).astype(xp.float32)
         obj.set_value(data)
         np.testing.assert_array_equal(cpuArray(obj.array_for_display()), cpuArray(data))

--- a/test/test_phase_flattening.py
+++ b/test/test_phase_flattening.py
@@ -181,3 +181,33 @@ class TestPhaseFlattening(unittest.TestCase):
         # Check no reallocation occurred
         assert id(phase_flattener.outputs['out_ef'].field) == output_field_id, \
             "Output field should not be reallocated"
+
+    @cpu_and_gpu
+    def test_phase_flattening_shape(self, target_device_idx, xp):
+        """Test that phase flattening doesn't cause memory reallocation"""
+        dimx = 10
+        dimy = 20
+        pixel_pitch = 0.1
+
+        # Create phase flattener
+        phase_flattener = PhaseFlattening(
+            target_device_idx=target_device_idx
+        )
+
+        # Create input
+        ef_in = ElectricField(dimx, dimy, pixel_pitch, 
+                             S0=1, target_device_idx=target_device_idx)
+        ef_in.A[:] = 1
+        ef_in.phaseInNm[:] = 100
+
+        phase_flattener.inputs['in_ef'].set(ef_in)
+
+        # First trigger to setup
+        t = 1
+        ef_in.generation_time = t
+        phase_flattener.check_ready(t)
+        phase_flattener.setup()
+        phase_flattener.trigger()
+        phase_flattener.post_trigger()
+
+        assert phase_flattener.outputs['out_ef'].A.shape == (dimy, dimx)

--- a/test/test_pixels.py
+++ b/test/test_pixels.py
@@ -40,6 +40,13 @@ class TestPixels(unittest.TestCase):
             pass
 
     @cpu_and_gpu
+    def test_pixels_shape(self, target_device_idx, xp):
+        dimx = 10
+        dimy = 20
+        obj = Pixels(dimx, dimy, bits=16, signed=0, target_device_idx=target_device_idx)
+        self.assertEqual(obj.pixels.shape, (dimy, dimx))
+
+    @cpu_and_gpu
     def test_set_value_does_not_reallocate(self, target_device_idx, xp):
         
         pixels = Pixels(10, 10, target_device_idx=target_device_idx)
@@ -70,7 +77,9 @@ class TestPixels(unittest.TestCase):
     @cpu_and_gpu
     def test_fits_header(self, target_device_idx, xp):
         
-        pixels = Pixels(6, 5, bits=8, signed=1, target_device_idx=target_device_idx)
+        dimx = 6
+        dimy = 5
+        pixels = Pixels(dimx, dimy, bits=8, signed=1, target_device_idx=target_device_idx)
         hdr = pixels.get_fits_header()
         
         assert type(hdr) is fits.Header
@@ -80,8 +89,8 @@ class TestPixels(unittest.TestCase):
         assert hdr['BPP'] == 8
         assert hdr['BYTESPP'] == 1
         assert hdr['SIGNED'] == 1
-        assert hdr['DIMX'] == 6
-        assert hdr['DIMY'] == 5
+        assert hdr['DIMX'] == dimx
+        assert hdr['DIMY'] == dimy
 
     @cpu_and_gpu
     def test_set_with_invalid_shape(self, target_device_idx, xp):


### PR DESCRIPTION
We never noticed these bugs because we always use square arrays, but we need to enforce the standard convention of x=horizontal and y=vertical, while the numpy shape is (rows, cols), therefore:

shape == (y, x)

Even better would be to get rid of x/y and always use shapes, but that's a much bigger change...
