### PR TITLE
Allow trigger when all inputs are optional

### DIFF
--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -55,9 +55,21 @@ class BaseProcessingObj(BaseTimeObj):
         self.remote_outputs[name].append(remote_output)
 
     def checkInputTimes(self):
+        '''
+        Determine whether this processing object needs to execute
+        the trigger method, based on the input states
+        '''
+        # No inputs: always trigger
         if len(self.inputs)==0:
             return True
-        self.get_all_inputs()
+
+        # Inputs are all optional, and none of them is set: always trigger
+        if all((self.inputs[k].optional is True and
+                self.local_inputs[k] is None)
+               for k in self.inputs):
+            return True
+
+        # Otherwise, only trigger if at least one input has been refreshed.
         for input_name, input_obj in self.local_inputs.items():
             if type(input_obj) is not list:
                 input_obj = [input_obj]

--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -63,6 +63,8 @@ class BaseProcessingObj(BaseTimeObj):
         if len(self.inputs)==0:
             return True
 
+        self.get_all_inputs()
+
         # Inputs are all optional, and none of them is set: always trigger
         if all((self.inputs[k].optional is True and
                 self.local_inputs[k] is None)
@@ -135,7 +137,7 @@ class BaseProcessingObj(BaseTimeObj):
         '''
         # Double check that we can execute
         if not self.inputs_changed:
-            raise RuntimeError("trigger() called when the object's inputs have not changed")
+            raise RuntimeError("post_trigger() called when the object's inputs have not changed")
 
         # Reset inputs flag
         self.inputs_changed = False

--- a/test/test_base_processing_obj.py
+++ b/test/test_base_processing_obj.py
@@ -6,6 +6,8 @@ import unittest
 from unittest.mock import MagicMock
 
 from specula import cp, cpuArray
+from specula.base_value import BaseValue
+from specula.connections import InputValue
 from specula.base_processing_obj import BaseProcessingObj
 
 from test.specula_testlib import cpu_and_gpu
@@ -99,6 +101,28 @@ class TestBaseProcessingObj(unittest.TestCase):
 
         obj.current_time = 0
         self.assertTrue(obj.checkInputTimes())
+
+    @cpu_and_gpu
+    def test_check_input_times_returns_true_for_invalid_optional_inputs(self, target_device_idx, xp):
+        obj = BaseProcessingObj(target_device_idx=target_device_idx)
+
+        obj.inputs['test1'] = InputValue(type=BaseValue, optional=True)
+        obj.inputs['test2'] = InputValue(type=BaseValue, optional=True)
+        obj.local_inputs['test1'] = None
+        obj.local_inputs['test2'] = None
+        self.assertTrue(obj.checkInputTimes())
+
+    @cpu_and_gpu
+    def test_check_input_times_returns_false_for_valid_optional_inputs(self, target_device_idx, xp):
+        obj = BaseProcessingObj(target_device_idx=target_device_idx)
+
+        obj.inputs['test1'] = InputValue(type=BaseValue, optional=True)
+        obj.inputs['test2'] = InputValue(type=BaseValue, optional=True)
+        obj.local_inputs['test1'] = BaseValue()
+        obj.local_inputs['test2'] = None
+        obj.local_inputs['test1'].generation_time = 1 # Simulate non-refreshed inputs
+        obj.current_time = 2
+        self.assertFalse(obj.checkInputTimes())
 
     @cpu_and_gpu
     def test_post_trigger_resets_inputs_changed(self, target_device_idx, xp):

--- a/test/test_base_processing_obj.py
+++ b/test/test_base_processing_obj.py
@@ -108,8 +108,6 @@ class TestBaseProcessingObj(unittest.TestCase):
 
         obj.inputs['test1'] = InputValue(type=BaseValue, optional=True)
         obj.inputs['test2'] = InputValue(type=BaseValue, optional=True)
-        obj.local_inputs['test1'] = None
-        obj.local_inputs['test2'] = None
         self.assertTrue(obj.checkInputTimes())
 
     @cpu_and_gpu
@@ -118,9 +116,11 @@ class TestBaseProcessingObj(unittest.TestCase):
 
         obj.inputs['test1'] = InputValue(type=BaseValue, optional=True)
         obj.inputs['test2'] = InputValue(type=BaseValue, optional=True)
-        obj.local_inputs['test1'] = BaseValue()
-        obj.local_inputs['test2'] = None
-        obj.local_inputs['test1'].generation_time = 1 # Simulate non-refreshed inputs
+
+        value = BaseValue()
+        obj.inputs['test1'].set(value)
+        value.generation_time = 1 # Simulate non-refreshed inputs
+
         obj.current_time = 2
         self.assertFalse(obj.checkInputTimes())
 

--- a/test/test_ciao_ciao_sensor.py
+++ b/test/test_ciao_ciao_sensor.py
@@ -4,6 +4,7 @@ import specula
 specula.init(0)
 
 from specula import cpuArray, np, RAD2ASEC
+from specula.loop_control import LoopControl
 from specula.data_objects.electric_field import ElectricField
 from specula.data_objects.pixels import Pixels
 from specula.data_objects.pupilstop import Pupilstop
@@ -220,13 +221,12 @@ class TestCiaoCiaoSensor(unittest.TestCase):
         ef = ElectricField(dim, dim, 0.01, S0=1.0, target_device_idx=target_device_idx)
         ef.A[:] = pupil_mask
         ef.phaseInNm[:] = phase_nm
-        ef.generation_time = t
-
+        ef.generation_time = 0
         wfs.inputs['in_ef'].set(ef)
-        wfs.setup()
-        wfs.check_ready(t)
-        wfs.trigger()
-        wfs.post_trigger()
+
+        loop = LoopControl()
+        loop.add(wfs, idx=0)
+        loop.run(run_time=1, dt=1)
 
         out = cpuArray(wfs.outputs['out_i'].i)
         cos_delta = np.clip(out / 2.0 - 1.0, -1.0, 1.0)

--- a/test/test_data_store.py
+++ b/test/test_data_store.py
@@ -13,6 +13,7 @@ import unittest
 from unittest.mock import patch
 
 from specula.connections import InputValue
+from specula.loop_control import LoopControl
 from specula.base_data_obj import BaseDataObj
 from specula.base_value import BaseValue
 from specula.processing_objects.data_store import DataStore
@@ -60,15 +61,16 @@ class TestDataStore(unittest.TestCase):
         self._connect_input(store, 'slow', slow)
         store.setup()
 
+        loop = LoopControl()
+        loop.add(store, idx=0)
+        loop.start(run_time=store.t_to_seconds(6), dt=store.t_to_seconds(1))
+
         for t in range(6):
             fast.set_value(np.array([10 + t], dtype=np.float32))
-            fast.generation_time = t
+            fast.generation_time = t 
             slow.set_value(np.array([20 + t], dtype=np.float32))
             slow.generation_time = t
-
-            store.check_ready(t)
-            store.trigger()
-            store.post_trigger()
+            loop.iter()
 
         self.assertEqual(list(store.storage['fast'].keys()), [0, 2, 4])
         self.assertEqual(list(store.storage['slow'].keys()), [0, 2, 4])

--- a/test/test_ideal_derivative_sensor.py
+++ b/test/test_ideal_derivative_sensor.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 
 from specula import cpuArray, RAD2ASEC
+from specula.loop_control import LoopControl
 from specula.data_objects.electric_field import ElectricField
 from specula.data_objects.pixels import Pixels
 from specula.data_objects.simul_params import SimulParams
@@ -146,32 +147,24 @@ class TestIdealDerivativeSensor(unittest.TestCase):
         print("min max of x_tilt:", x_tilt.min(), x_tilt.max())
 
         ef.phaseInNm[:] = x_tilt
-        ef.generation_time = t
+        ef.generation_time = 0
 
         # Process with SH
         sh.inputs['in_ef'].set(ef)
-        sh.setup()
-        sh.check_ready(t)
-        sh.trigger()
-        sh.post_trigger()
 
-        # Process SH output with slopec
         pixels = Pixels(*sh.outputs['out_i'].i.shape, target_device_idx=target_device_idx)
         pixels.pixels = sh.outputs['out_i'].i
-        pixels.generation_time = t
+        pixels.generation_time = 0
 
         slopec.inputs['in_pixels'].set(pixels)
-        slopec.setup()
-        slopec.check_ready(t)
-        slopec.trigger()
-        slopec.post_trigger()
-
-        # Process with IdealDerivativeSensor
         ideal_sensor.inputs['in_ef'].set(ef)
-        ideal_sensor.setup()
-        ideal_sensor.check_ready(t)
-        ideal_sensor.trigger()
-        ideal_sensor.post_trigger()
+
+
+        loop = LoopControl()
+        loop.add(sh, idx=0)
+        loop.add(ideal_sensor, idx=0)
+        loop.add(slopec, idx=1)
+        loop.run(run_time=1, dt=1)
 
         # Compare slopes
         sh_slopes_x = cpuArray(slopec.outputs['out_slopes'].xslopes)


### PR DESCRIPTION
Currently, an object with optional inputs that are disconnected will never trigger.
This PR adds code to check whether all inputs of a processing object are optional and, if they are all disconnected, will force the trigger to be executed.
This can happen with object that produce data without needing an input, like a CCD laboratory device, that optionally have a sync input to trigger only at specific times. If this optional input is not given, the object must always trigger.