### PR TITLE
Fixed synim==1.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ astropy
 matplotlib
 symao >= 1.0.1
 astro-seeing >= 1.1
-synim >= 1.0.0
+synim == 1.0.5
 flask-socketio
 python-socketio
 requests


### PR DESCRIPTION
More recent versions make SPRINT tests fail