### PR TITLE
(GA) Implement base ModalRec class and update tests

### DIFF
--- a/config/ANDES/params_andes.yml
+++ b/config/ANDES/params_andes.yml
@@ -164,7 +164,7 @@ modalrec:
   nmodes:             4000                   # number of modes
   inputs:
     in_slopes: 'slopec.out_slopes'
-  outputs: ['out_modes', 'out_pseudo_ol_modes']
+  outputs: ['out_modes']
 
 
 gain_ramp:

--- a/config/ANDES/params_andes_1kHz.yml
+++ b/config/ANDES/params_andes_1kHz.yml
@@ -146,7 +146,7 @@ modalrec:
   nmodes:             4000                   # number of modes
   inputs:
     in_slopes: 'slopec.out_slopes'
-  outputs: ['out_modes', 'out_pseudo_ol_modes']
+  outputs: ['out_modes']
 
 
 gain_ramp:

--- a/config/MORFEO/params_morfeo_focus_ref.yml
+++ b/config/MORFEO/params_morfeo_focus_ref.yml
@@ -379,7 +379,7 @@ tomo_ngs:
   recmat_object:      '20240613_200330.0/recmat' # NGS at 55asec
   inputs:
     in_slopes_list:        ['slopec_ngs1.out_slopes','slopec_ngs2.out_slopes','slopec_ngs3.out_slopes']
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 iir_ngs:
   class:             'Integrator'

--- a/config/MORFEO/params_morfeo_focus_ref.yml
+++ b/config/MORFEO/params_morfeo_focus_ref.yml
@@ -354,7 +354,6 @@ tomo_polc_lgs:
   recmat_object:      '20240606_200110.0/recmat' # 35015 modes, Tallon, focus filtered
   projmat_object:     'p20240607_025755.0/projmatAll' # 6564x35015 modes
   intmat_object:      '20250911_000002.0/intmat' # 6564 modes
-  in_commands_size:   6564
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes','slopec_lgs4.out_slopes','slopec_lgs5.out_slopes','slopec_lgs6.out_slopes']
     in_commands:            'iir_lgs.out_comm_no_delay:-1'

--- a/config/MORFEO/params_morfeo_focus_ref.yml
+++ b/config/MORFEO/params_morfeo_focus_ref.yml
@@ -350,11 +350,10 @@ slopec_ref3: { <<: *REF_SLOPEC, inputs: {in_pixels: 'detector_ref3.out_pixels' }
 # -----------------------------
 
 tomo_polc_lgs:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
   recmat_object:      '20240606_200110.0/recmat' # 35015 modes, Tallon, focus filtered
   projmat_object:     'p20240607_025755.0/projmatAll' # 6564x35015 modes
   intmat_object:      '20250911_000002.0/intmat' # 6564 modes
-  polc:   true
   in_commands_size:   6564
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes','slopec_lgs4.out_slopes','slopec_lgs5.out_slopes','slopec_lgs6.out_slopes']

--- a/config/MORFEO/params_morfeo_full.yml
+++ b/config/MORFEO/params_morfeo_full.yml
@@ -364,7 +364,6 @@ tomo_polc_lgs:
   recmat_object:      '20240606_200110.0/recmat'
   projmat_object:     'p20250519_195705.0/projmatAll.fits'
   intmat_object:      '20250911_000003.0/intmat.fits'
-  in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes','slopec_lgs4.out_slopes','slopec_lgs5.out_slopes','slopec_lgs6.out_slopes']
     in_commands:            'iir_lgs.out_comm_no_delay:-1'
@@ -561,7 +560,6 @@ tomo_polc_ref:
   recmat_object:      '20240614_194901.0/recmat'
   projmat_object:     'p20240526_141118.0/projmatAll'
   intmat_object:      '20250326_000001.0/intmat'
-  in_commands_size:   293
   inputs:
     in_slopes_list:        ['slopec_ref1.out_slopes','slopec_ref2.out_slopes','slopec_ref3.out_slopes']
     in_commands:            'control_ref.out_comm:-1'

--- a/config/MORFEO/params_morfeo_full.yml
+++ b/config/MORFEO/params_morfeo_full.yml
@@ -501,7 +501,7 @@ dm3:
 # ----------------
 
 tomo_ngs:
-  class:              'Modalrec'
+  class:              'ModalreExplicitPolc'
   recmat_object:      '20240614_073541.0/recmat'
   projmat_object:     'p20230222_104426.0/projmatAll'
   inputs:

--- a/config/MORFEO/params_morfeo_full.yml
+++ b/config/MORFEO/params_morfeo_full.yml
@@ -360,11 +360,10 @@ lift:
 # -----------------------------
 
 tomo_polc_lgs:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
   recmat_object:      '20240606_200110.0/recmat'
   projmat_object:     'p20250519_195705.0/projmatAll.fits'
   intmat_object:      '20250911_000003.0/intmat.fits'
-  polc:   true
   in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes','slopec_lgs4.out_slopes','slopec_lgs5.out_slopes','slopec_lgs6.out_slopes']
@@ -558,11 +557,10 @@ iir_focus:
 # --------------
 
 tomo_polc_ref:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
   recmat_object:      '20240614_194901.0/recmat'
   projmat_object:     'p20240526_141118.0/projmatAll'
   intmat_object:      '20250326_000001.0/intmat'
-  polc:   true
   in_commands_size:   293
   inputs:
     in_slopes_list:        ['slopec_ref1.out_slopes','slopec_ref2.out_slopes','slopec_ref3.out_slopes']

--- a/config/MORFEO/params_morfeo_ltao.yml
+++ b/config/MORFEO/params_morfeo_ltao.yml
@@ -341,14 +341,12 @@ slopec6:
   outputs:  ['out_slopes', 'out_subapdata']
 
 rec:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
 #  recmat_object:      'maory_np_ps480p0.080_shs68x68_wl589_fv16.1_np14_th0.50_mn1000_ce'         # reconstruction matrix tag£
   #recmat_object:      'MORFEO_LTAO'         # reconstruction matrix tag
   recmat_object: '/raid1/guido/PASSATA/MAORYC/rec/20241127_110943.0/recmat'
   intmat_object: '/raid1/guido/PASSATA/MAORYC/im/MORFEO_IM_LTAO_intmat'
   projmat_object: '/raid1/guido/PASSATA/MAORYC/rec/p20241127_110943.0/projmat1'
-
-  polc: True
   in_commands_size: 4519
   inputs:
     in_slopes_list:        ['slopec1.out_slopes','slopec2.out_slopes','slopec3.out_slopes','slopec4.out_slopes','slopec5.out_slopes','slopec6.out_slopes']

--- a/config/MORFEO/params_morfeo_ltao.yml
+++ b/config/MORFEO/params_morfeo_ltao.yml
@@ -347,7 +347,6 @@ rec:
   recmat_object: '/raid1/guido/PASSATA/MAORYC/rec/20241127_110943.0/recmat'
   intmat_object: '/raid1/guido/PASSATA/MAORYC/im/MORFEO_IM_LTAO_intmat'
   projmat_object: '/raid1/guido/PASSATA/MAORYC/rec/p20241127_110943.0/projmat1'
-  in_commands_size: 4519
   inputs:
     in_slopes_list:        ['slopec1.out_slopes','slopec2.out_slopes','slopec3.out_slopes','slopec4.out_slopes','slopec5.out_slopes','slopec6.out_slopes']
     in_commands: 'control.out_comm:-1'

--- a/config/MORFEO/params_morfeo_no_focus_no_ref.yml
+++ b/config/MORFEO/params_morfeo_no_focus_no_ref.yml
@@ -302,11 +302,10 @@ slopec_ngs3: { <<: *NGS_SLOPEC, inputs: {in_pixels: 'detector_ngs3.out_pixels' }
 # -----------------------------
 
 tomo_polc_lgs:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
   recmat_object:      '20231207_111630.0/recmat' # Tallon
   projmat_object:     'p20231207_063630.0/projmatAll' # 6258 modes
   intmat_object:      '20250911_000001.0/intmat' # 6258 modes
-  polc:   true
   in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes',

--- a/config/MORFEO/params_morfeo_no_focus_no_ref.yml
+++ b/config/MORFEO/params_morfeo_no_focus_no_ref.yml
@@ -306,7 +306,6 @@ tomo_polc_lgs:
   recmat_object:      '20231207_111630.0/recmat' # Tallon
   projmat_object:     'p20231207_063630.0/projmatAll' # 6258 modes
   intmat_object:      '20250911_000001.0/intmat' # 6258 modes
-  in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes',
                             'slopec_lgs4.out_slopes','slopec_lgs5.out_slopes','slopec_lgs6.out_slopes']

--- a/config/MORFEO/params_morfeo_no_na_no_focus_no_ref.yml
+++ b/config/MORFEO/params_morfeo_no_na_no_focus_no_ref.yml
@@ -289,11 +289,10 @@ slopec_ngs3: { <<: *NGS_SLOPEC, inputs: {in_pixels: 'detector_ngs3.out_pixels' }
 # -----------------------------
 
 tomo_polc_lgs:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
   recmat_object:      '20231207_063630.0/recmat'
   projmat_object:     'p20231207_063630.0/projmatAll' # 6258 modes
   intmat_object:      '20250911_000001.0/intmat' # 6258 modes
-  polc:   true
   in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes',

--- a/config/MORFEO/params_morfeo_no_na_no_focus_no_ref.yml
+++ b/config/MORFEO/params_morfeo_no_na_no_focus_no_ref.yml
@@ -293,7 +293,6 @@ tomo_polc_lgs:
   recmat_object:      '20231207_063630.0/recmat'
   projmat_object:     'p20231207_063630.0/projmatAll' # 6258 modes
   intmat_object:      '20250911_000001.0/intmat' # 6258 modes
-  in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes',
                             'slopec_lgs4.out_slopes','slopec_lgs5.out_slopes','slopec_lgs6.out_slopes']

--- a/config/MORFEO/params_morfeo_small.yml
+++ b/config/MORFEO/params_morfeo_small.yml
@@ -270,7 +270,6 @@ tomo_polc_lgs:
   recmat_object:      '20240606_200110.0/recmat'
   projmat_object:     'p20250519_195705.0/projmatAll.fits'
   intmat_object:      '20250911_000003.0/intmat.fits'
-  in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes',
                             'slopec_lgs4.out_slopes','slopec_lgs5.out_slopes','slopec_lgs6.out_slopes']

--- a/config/MORFEO/params_morfeo_small.yml
+++ b/config/MORFEO/params_morfeo_small.yml
@@ -266,11 +266,10 @@ slopec_ngs3: { <<: *NGS_SLOPEC, inputs: {in_pixels: 'detector_ngs3.out_pixels' }
 # -----------------------------
 
 tomo_polc_lgs:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
   recmat_object:      '20240606_200110.0/recmat'
   projmat_object:     'p20250519_195705.0/projmatAll.fits'
   intmat_object:      '20250911_000003.0/intmat.fits'
-  polc:   true
   in_commands_size:   6258
   inputs:
     in_slopes_list:        ['slopec_lgs1.out_slopes','slopec_lgs2.out_slopes','slopec_lgs3.out_slopes',

--- a/config/MORFEO/params_morfeo_small.yml
+++ b/config/MORFEO/params_morfeo_small.yml
@@ -344,7 +344,7 @@ dm3:
 # ----------------
 
 tomo_ngs:
-  class:              'Modalrec'
+  class:              'ModalrecExplicitPolc'
   recmat_object:      '20240614_073541.0/recmat'
   projmat_object:     'p20230222_104426.0/projmatAll'
   inputs:

--- a/config/scao/params_scao_elt.yml
+++ b/config/scao/params_scao_elt.yml
@@ -107,7 +107,7 @@ rec:
   recmat_object:      'hiresA_ps512p0.076_pyr90x90_wl798_fv2.1_ft3.0_ma4_bn1_th0.30a0.30b_mn4094'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/config/scao/params_scao_elt_plots.yml
+++ b/config/scao/params_scao_elt_plots.yml
@@ -107,7 +107,7 @@ rec:
   recmat_object:      'hiresA_ps512p0.076_pyr90x90_wl798_fv2.1_ft3.0_ma4_bn1_th0.30a0.30b_mn4094'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/config/scao/params_scao_plots.yml
+++ b/config/scao/params_scao_plots.yml
@@ -107,7 +107,7 @@ rec:
   recmat_object:      'scao_recmat'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/config/scao/params_scao_pyr.yml
+++ b/config/scao/params_scao_pyr.yml
@@ -108,7 +108,7 @@ rec:
   recmat_object:      'scao_pyr_rec'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/config/scao/params_scao_pyr_extended.yml
+++ b/config/scao/params_scao_pyr_extended.yml
@@ -121,7 +121,7 @@ rec:
   recmat_object:      'scao_pyr_rec'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/config/scao/params_scao_sh.yml
+++ b/config/scao/params_scao_sh.yml
@@ -108,7 +108,7 @@ rec:
   recmat_object:      'scao_sh_rec5'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/config/scao/params_scao_sh_plots.yml
+++ b/config/scao/params_scao_sh_plots.yml
@@ -107,7 +107,7 @@ rec:
   recmat_object:      'scao_sh_rec5'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/docs/tutorials/scao_basic_tutorial.rst
+++ b/docs/tutorials/scao_basic_tutorial.rst
@@ -229,7 +229,7 @@ Create a YAML configuration file, for example ``params_scao_pyr_basic.yml``:
      recmat_object:      'scao_pyr_rec'         # reconstruction matrix tag
      inputs:
        in_slopes:        'slopec.out_slopes'
-     outputs:  ['out_modes', 'out_pseudo_ol_modes'] 
+     outputs:  ['out_modes'] 
 
    # The control block computes the control commands based on the differential modal coefficients.
    # The modal coefficients are differential because it operates in closed loop.

--- a/specula/processing_objects/base_modalrec.py
+++ b/specula/processing_objects/base_modalrec.py
@@ -1,0 +1,65 @@
+from specula.base_processing_obj import BaseProcessingObj, InputDesc, OutputDesc
+from specula.base_value import BaseValue
+from specula.connections import InputList, InputValue
+from specula.data_objects.slopes import Slopes
+
+class BaseModalrec(BaseProcessingObj):
+    """
+    Base Modal Reconstructor processing object.
+    Handles common slope inputs, modal outputs, and memory allocation
+    for all modal reconstructors. Specific algorithms implement trigger_code().
+    """
+
+    def __init__(self, target_device_idx: int = None, precision: int = None):
+        super().__init__(target_device_idx=target_device_idx, precision=precision)
+
+        self.slopes = None  # to be allocated in setup()
+
+        self.modes = BaseValue('output modes',
+                               target_device_idx=target_device_idx,
+                               precision=precision)
+
+        self.inputs['in_slopes'] = InputValue(type=Slopes, optional=True)
+        self.inputs['in_slopes_list'] = InputList(type=Slopes, optional=True)
+        self.outputs['out_modes'] = self.modes
+
+    @classmethod
+    def input_names(cls):
+        return {
+            'in_slopes': InputDesc(Slopes,
+                         'Input wavefront slope vector (optional)'),
+            'in_slopes_list': InputDesc(Slopes,
+                              'List of input slope vectors (optional)')
+        }
+
+    @classmethod
+    def output_names(cls):
+        return {'out_modes': OutputDesc(BaseValue, 'Reconstructed modal command vector')}
+
+    def setup(self):
+        super().setup()
+
+        slopes = self.local_inputs['in_slopes']
+        slopes_list = self.local_inputs['in_slopes_list']
+
+        if not slopes and (not slopes_list or not all(slopes_list)):
+            raise ValueError("Either 'in_slopes' or 'in_slopes_list' must be given as an input")
+
+        if slopes is None:
+            self.slopes = self.xp.hstack([x.slopes for x in slopes_list])
+        else:
+            self.slopes = self.to_xp(slopes.slopes.copy())
+
+    def prepare_trigger(self, t):
+        super().prepare_trigger(t)
+
+        slopes = self.local_inputs['in_slopes']
+        slopes_list = self.local_inputs['in_slopes_list']
+
+        if slopes is None:
+            self.slopes[:] = self.xp.hstack([x.slopes for x in slopes_list])
+        else:
+            self.slopes[:] = slopes.slopes
+
+    def trigger_code(self):
+        raise NotImplementedError("Subclasses must implement the trigger_code method.")

--- a/specula/processing_objects/modalrec.py
+++ b/specula/processing_objects/modalrec.py
@@ -11,7 +11,6 @@ class Modalrec(BaseModalrec):
     def __init__(self,
                  recmat: Recmat,
                  nmodes: int = None,
-                 filtmat = None,
                  ncutmodes: int = None,
                  target_device_idx: int = None,
                  precision: int = None):
@@ -19,10 +18,6 @@ class Modalrec(BaseModalrec):
 
         if ncutmodes:
             recmat.reduce_size(ncutmodes)
-
-        if filtmat is not None:
-            recmat.recmat = recmat.recmat @ filtmat
-            self.logger.info('recmat updated with filtmat!')
 
         self.recmat = recmat
         nmodes = self.recmat.nmodes

--- a/specula/processing_objects/modalrec.py
+++ b/specula/processing_objects/modalrec.py
@@ -9,38 +9,24 @@ class Modalrec(BaseModalrec):
     """
 
     def __init__(self,
+                 recmat: Recmat,
                  nmodes: int = None,
-                 recmat: Recmat = None,
                  filtmat = None,
-                 identity: bool = False,
                  ncutmodes: int = None,
                  target_device_idx: int = None,
                  precision: int = None):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
 
-        if recmat is None:
-            if identity:
-                if nmodes is None:
-                    raise ValueError('modalrec nmodes key must be set when using identity!')
-                recmat = Recmat(self.xp.identity(nmodes),
-                                target_device_idx=target_device_idx, precision=precision)
-
         if ncutmodes:
-            if recmat is not None:
-                recmat.reduce_size(ncutmodes)
-            else:
-                self.logger.warning('recmat cannot be reduced because it is null.')
+            recmat.reduce_size(ncutmodes)
 
-        if filtmat is not None and recmat is not None:
+        if filtmat is not None:
             recmat.recmat = recmat.recmat @ filtmat
             self.logger.info('recmat updated with filtmat!')
 
         self.recmat = recmat
-        if self.recmat is not None:
-            nmodes = self.recmat.nmodes
-
-        if nmodes is not None:
-            self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)
+        nmodes = self.recmat.nmodes
+        self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)
 
     def trigger_code(self):
         self.modes.value[:] = self.recmat.recmat @ self.slopes

--- a/specula/processing_objects/modalrec.py
+++ b/specula/processing_objects/modalrec.py
@@ -43,10 +43,5 @@ class Modalrec(BaseModalrec):
             self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)
 
     def trigger_code(self):
-        if self.recmat is None or self.recmat.recmat is None:
-            self.logger.warning("Skipping reconstruction because recmat is NULL")
-            return
-
-        # Memory pre-allocation optimization
         self.modes.value[:] = self.recmat.recmat @ self.slopes
         self.modes.generation_time = self.current_time

--- a/specula/processing_objects/modalrec.py
+++ b/specula/processing_objects/modalrec.py
@@ -1,231 +1,52 @@
-from specula.base_processing_obj import BaseProcessingObj, InputDesc, OutputDesc
-from specula.base_value import BaseValue
-from specula.connections import InputList, InputValue
-from specula.data_objects.intmat import Intmat
+from specula.processing_objects.base_modalrec import BaseModalrec
 from specula.data_objects.recmat import Recmat
-from specula.data_objects.slopes import Slopes
 
 
-class Modalrec(BaseProcessingObj):
+class Modalrec(BaseModalrec):
     """
-    Modal reconstructor processing object.
+    Standard modal reconstructor processing object.
+    Performs pure matrix-vector multiplication: modes = recmat @ slopes.
     """
 
     def __init__(self,
-                 nmodes: int=None,      # TODO =0,
-                 recmat: Recmat=None,
-                 projmat: Recmat=None,
-                 intmat: Intmat=None,
-                 polc: bool=False,
-                 in_commands_size: int=None,
+                 nmodes: int = None,
+                 recmat: Recmat = None,
                  filtmat = None,
-                 identity: bool=False,
-                 ncutmodes: int=None,
-                 nSlopesToBeDiscarded: int=None,
-                 dmNumber: int=0,
-                 noProj: bool=False,
-                 target_device_idx: int=None,
-                 precision: int=None
-                ):
+                 identity: bool = False,
+                 ncutmodes: int = None,
+                 target_device_idx: int = None,
+                 precision: int = None):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
 
-        if polc:
+        if recmat is None:
             if identity:
-                raise ValueError('identity cannot be set with POLC.')
-            if ncutmodes is not None:
-                raise ValueError('ncutmodes cannot be set with POLC.')
-        else:
-            if recmat is None:
-                if identity:
-#                    if nmodes<=0:  # TODO new code to be tested
-                    if nmodes is None:
-                        raise ValueError('modalrec nmodes key must be set!')
-                    recmat = Recmat(self.xp.identity(nmodes),
-                                    target_device_idx=target_device_idx, precision=precision)
-                elif intmat:
-                    if nmodes:
-                        nmodesintmat = intmat.size[0]
-                        intmat.reduce_size(nmodesintmat - nmodes)
-                    if nSlopesToBeDiscarded:
-                        intmat.reduce_slopes(nSlopesToBeDiscarded)
-                    recmat = Recmat(intmat.intmat,
-                                    target_device_idx=target_device_idx, precision=precision)
+                if nmodes is None:
+                    raise ValueError('modalrec nmodes key must be set when using identity!')
+                recmat = Recmat(self.xp.identity(nmodes),
+                                target_device_idx=target_device_idx, precision=precision)
 
-            if ncutmodes:
-                if recmat is not None:
-                    recmat.reduce_size(ncutmodes)
-                else:
-                    self.logger.warning('recmat cannot be reduced because it is null.')
-
-
-        if recmat is not None:
-            if projmat is None and recmat.proj_list and not noProj:
-                if dmNumber is not None:
-                    if dmNumber <= 0:
-                        raise ValueError('dmNumber must be > 0')
-                    projmat = Recmat(recmat.proj_list[dmNumber - 1],
-                                     target_device_idx=target_device_idx, precision=precision)
-                else:
-                    raise ValueError('dmNumber (>0) must be defined if projmat_tag is not defined!')
+        if ncutmodes:
+            if recmat is not None:
+                recmat.reduce_size(ncutmodes)
+            else:
+                self.logger.warning('recmat cannot be reduced because it is null.')
 
         if filtmat is not None and recmat is not None:
             recmat.recmat = recmat.recmat @ filtmat
-            self.logger.info('recmat updated with filmat!')
-
-        if polc:
-            if not intmat:
-                raise ValueError("Intmat object not valid")
+            self.logger.info('recmat updated with filtmat!')
 
         self.recmat = recmat
-        self.projmat = projmat
-        self.intmat = intmat
-        self.polc = polc
-        if in_commands_size is None and polc:
-            in_commands_size = intmat.intmat.shape[1]
-        self.in_commands_size = in_commands_size
-
-        if polc:
-            nmodes = self.projmat.nmodes
-        else:
+        if self.recmat is not None:
             nmodes = self.recmat.nmodes
 
-        self.modes = BaseValue('output modes from modal reconstructor',
-                               target_device_idx=target_device_idx,
-                               precision=precision)
-        self.pseudo_ol_modes = BaseValue('output POL modes from modal reconstructor',
-                                         target_device_idx=target_device_idx,
-                                         precision=precision)
-
-        self.commands = None  # to be allocated in setup
-        self.slopes = None    # to be allocated in setup
-
-        self.inputs['in_slopes'] = InputValue(type=Slopes, optional=True)
-        self.inputs['in_slopes_list'] = InputList(type=Slopes, optional=True)
-        self.outputs['out_modes'] = self.modes
-        self.outputs['out_pseudo_ol_modes'] = self.pseudo_ol_modes
-
-        # TODO static allocation but polc not supported (should use projmat)
-        self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)
-        self.pseudo_ol_modes.value = self.xp.zeros(nmodes, dtype=self.dtype)
-
-        if self.polc:
-            self.out_comm = BaseValue('output commands from modal reconstructor',
-                                      target_device_idx=target_device_idx,
-                                      precision=precision)
-            self.inputs['in_commands'] = InputValue(type=BaseValue, optional=True)
-            self.inputs['in_commands_list'] = InputList(type=BaseValue, optional=True)
-            # TODO complete static allocation above
-
-    @classmethod
-    def input_names(cls):
-        return {'in_slopes': InputDesc(Slopes, 'Input wavefront slope vector (optional, use with in_slopes_list)'),
-                'in_slopes_list': InputDesc(Slopes, 'List of input slope vectors for multi-sensor reconstruction (optional)'),
-                'in_commands': InputDesc(BaseValue, 'Current output command vector for POLC (optional)'),
-                'in_commands_list': InputDesc(BaseValue, 'List of current command vectors for POLC (optional)')}
-
-    @classmethod
-    def output_names(cls):
-        return {'out_modes': OutputDesc(BaseValue, 'Reconstructed modal command vector'),
-                'out_pseudo_ol_modes': OutputDesc(BaseValue, 'Pseudo open-loop modal estimate (only in POLC mode)')}
-
-    def prepare_trigger(self, t):
-        super().prepare_trigger(t)
-
-        slopes = self.local_inputs['in_slopes']
-        slopes_list = self.local_inputs['in_slopes_list']
-
-        if slopes is None:
-            self.slopes[:] = self.xp.hstack([x.slopes for x in slopes_list])
-        else:
-            self.slopes[:] = slopes.slopes
-
-        if self.polc:
-            commands = self.local_inputs['in_commands']
-            commands_list = self.local_inputs['in_commands_list']
-            if commands is None:
-                self.commands[:] = self.xp.hstack([x.commands for x in commands_list])
-            else:
-                if commands.value is None:
-                    # value will be None in the first iteration
-                    self.commands[:] = 0.0
-                else:
-                    self.commands[:] = commands.value
-
-            if self.intmat is not None and self.intmat.intmat is not None:
-                # Check dimensions for slopes
-                expected_slopes_size = self.intmat.intmat.shape[0]
-                if expected_slopes_size != len(self.slopes):
-                    raise ValueError(f"Dimension mismatch in POLC mode: "
-                                f"intmat @ commands will produce {expected_slopes_size} slopes, "
-                                f"but input slopes has size {len(self.slopes)}")
+        if nmodes is not None:
+            self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)
 
     def trigger_code(self):
-        if self.recmat.recmat is None:
-            self.logger.warning("skipping reconstruction because recmat is NULL")
+        if self.recmat is None or self.recmat.recmat is None:
+            self.logger.warning("Skipping reconstruction because recmat is NULL")
             return
 
-        # In the polc case, commands may be *alwats* refreshed if they are set with -1
-        # (it might result in a kind of loop in the yml file)
-        # Therefor we check the slopes input time and only run when they have been refreshed.
-        if self.polc:
-
-            slopes = self.local_inputs['in_slopes']
-            slopes_list = self.local_inputs['in_slopes_list']
-
-            if slopes is not None:
-                slopes_time = slopes.generation_time
-            else:
-                slopes_time = slopes_list[0].generation_time
-
-            if slopes_time != self.current_time:
-                return
-
-
-        if self.polc:
-
-            # (1) Compute pseudo open loop modes
-            # (1.1) from commands to slopes
-            comm_slopes = self.intmat.intmat @ self.commands
-
-            # (1.2) from slopes to modes summing the measured slopes and the computed ones
-            #     (i.e., assuming that the DM perfectly reproduces the commands)
-            self.pseudo_ol_modes.value = self.recmat.recmat @ (self.slopes + comm_slopes)
-            self.pseudo_ol_modes.generation_time = self.current_time
-
-            # (2) from pseudo open loop modes to output modes
-            if self.projmat is None:
-                output_modes = self.pseudo_ol_modes.value
-            else:
-                output_modes = self.projmat.recmat @ self.pseudo_ol_modes.value
-
-            # (3) remove the effect of the commands
-            output_modes -= self.commands
-
-        else:
-            output_modes = self.recmat.recmat @ self.slopes
-
-        self.modes.value = output_modes
+        # Memory pre-allocation optimization
+        self.modes.value[:] = self.recmat.recmat @ self.slopes
         self.modes.generation_time = self.current_time
-
-    def setup(self):
-        super().setup()
-
-        slopes = self.local_inputs['in_slopes']
-        slopes_list = self.local_inputs['in_slopes_list']
-
-        if not slopes and (not slopes_list or not all(slopes_list)):
-            raise ValueError("Either 'slopes' or 'slopes_list' must be given as an input")
-
-        if slopes is None:
-            self.slopes = self.xp.hstack([x.slopes for x in slopes_list])
-        else:
-            self.slopes = self.to_xp(slopes.slopes.copy())
-
-        if self.polc:
-            commands = self.local_inputs['in_commands']
-            commands_list = self.local_inputs['in_commands_list']
-            if not commands and (not commands_list or not all(commands_list)):
-                raise ValueError("When POLC is used, either 'commands' or 'commands_list'"
-                                 "must be given as an input")
-
-            self.commands = self.xp.zeros(self.in_commands_size, dtype=self.dtype)

--- a/specula/processing_objects/modalrec_explicit_polc.py
+++ b/specula/processing_objects/modalrec_explicit_polc.py
@@ -19,7 +19,6 @@ class ModalrecExplicitPolc(BaseModalrec):
                  recmat: Recmat = None,
                  projmat: Recmat = None,
                  intmat: Intmat = None,
-                 in_commands_size: int = None,
                  nSlopesToBeDiscarded: int = None,
                  target_device_idx: int = None,
                  precision: int = None):
@@ -34,10 +33,8 @@ class ModalrecExplicitPolc(BaseModalrec):
         if self.intmat is not None:
             if nSlopesToBeDiscarded:
                 self.intmat.reduce_slopes(nSlopesToBeDiscarded)
-            if in_commands_size is None:
-                in_commands_size = self.intmat.intmat.shape[1]
-
-        if in_commands_size is None:
+            in_commands_size = self.intmat.nmodes
+        else:
             in_commands_size = self.recmat.nmodes
 
         self.in_commands_size = in_commands_size

--- a/specula/processing_objects/modalrec_explicit_polc.py
+++ b/specula/processing_objects/modalrec_explicit_polc.py
@@ -27,18 +27,19 @@ class ModalrecExplicitPolc(BaseModalrec):
 
         if recmat is None:
             raise ValueError("Explicit POLC requires a valid recmat.")
-        if intmat is None:
-            raise ValueError("Explicit POLC requires a valid intmat.")
-
-        if nSlopesToBeDiscarded:
-            intmat.reduce_slopes(nSlopesToBeDiscarded)
 
         self.recmat = recmat
         self.projmat = projmat
         self.intmat = intmat
+        if self.intmat is not None:
+            if nSlopesToBeDiscarded:
+                self.intmat.reduce_slopes(nSlopesToBeDiscarded)
+            if in_commands_size is None:
+                in_commands_size = self.intmat.intmat.shape[1]
 
         if in_commands_size is None:
-            in_commands_size = intmat.intmat.shape[1]
+            in_commands_size = self.recmat.nmodes
+
         self.in_commands_size = in_commands_size
 
         # Properly initialize nmodes based on projmat presence
@@ -130,9 +131,14 @@ class ModalrecExplicitPolc(BaseModalrec):
         if slopes_time != self.current_time:
             return
 
-        # (1) Compute pseudo open loop modes: R * (s + D * c)
-        comm_slopes = self.intmat.intmat @ self.commands
-        self.pseudo_ol_modes.value[:] = self.recmat.recmat @ (self.slopes + comm_slopes)
+        # (1) Compute pseudo open loop modes
+        if self.intmat is not None:
+            comm_slopes = self.intmat.intmat @ self.commands
+            self.pseudo_ol_modes.value[:] = self.recmat.recmat @ (self.slopes + comm_slopes)
+        else:
+            # Se non c'è intmat, usiamo solo gli slope misurati
+            self.pseudo_ol_modes.value[:] = self.recmat.recmat @ self.slopes
+        
         self.pseudo_ol_modes.generation_time = self.current_time
 
         # (2) Project to output modes

--- a/specula/processing_objects/modalrec_explicit_polc.py
+++ b/specula/processing_objects/modalrec_explicit_polc.py
@@ -65,7 +65,7 @@ class ModalrecExplicitPolc(BaseModalrec):
         inputs = super().input_names()
         inputs.update({
             'in_commands': InputDesc(BaseValue,
-                           'Current output command vector for explicit POLC'),
+                           'Current output command vector for explicit POLC (optional)'),
             'in_commands_list': InputDesc(BaseValue,
                                 'List of current command vectors for explicit POLC (optional)')
         })
@@ -83,6 +83,14 @@ class ModalrecExplicitPolc(BaseModalrec):
     def setup(self):
         super().setup()
 
+        # Dimension validation
+        if self.intmat is not None and self.intmat.intmat is not None:
+            expected_slopes_size = self.intmat.nslopes
+            if expected_slopes_size != len(self.slopes):
+                raise ValueError(f"Dimension mismatch in POLC mode: "
+                                 f"intmat @ commands will produce {expected_slopes_size} slopes, "
+                                 f"but input slopes has size {len(self.slopes)}")
+
         commands = self.local_inputs['in_commands']
         commands_list = self.local_inputs['in_commands_list']
 
@@ -90,6 +98,7 @@ class ModalrecExplicitPolc(BaseModalrec):
             raise ValueError("Either 'in_commands' or 'in_commands_list' must be given as an input")
 
         self.commands = self.xp.zeros(self.in_commands_size, dtype=self.dtype)
+
 
     def prepare_trigger(self, t):
         # Handle slopes via base class
@@ -107,14 +116,6 @@ class ModalrecExplicitPolc(BaseModalrec):
                 self.commands[:] = 0.0
             else:
                 self.commands[:] = commands.value
-
-        # Dimension validation
-        if self.intmat is not None and self.intmat.intmat is not None:
-            expected_slopes_size = self.intmat.intmat.shape[0]
-            if expected_slopes_size != len(self.slopes):
-                raise ValueError(f"Dimension mismatch in POLC mode: "
-                                 f"intmat @ commands will produce {expected_slopes_size} slopes, "
-                                 f"but input slopes has size {len(self.slopes)}")
 
     def trigger_code(self):
         # Check refresh based on slopes (standard POLC logic)

--- a/specula/processing_objects/modalrec_explicit_polc.py
+++ b/specula/processing_objects/modalrec_explicit_polc.py
@@ -1,0 +1,151 @@
+from specula.processing_objects.base_modalrec import BaseModalrec
+from specula.base_value import BaseValue
+from specula.connections import InputList, InputValue
+from specula.base_processing_obj import InputDesc, OutputDesc
+from specula.data_objects.intmat import Intmat
+from specula.data_objects.recmat import Recmat
+
+
+class ModalrecExplicitPolc(BaseModalrec):
+    """
+    Explicit Pseudo Open Loop Control (POLC) modal reconstructor processing object.
+    
+    This class explicitly reconstructs the slopes by summing the measured slopes
+    and the estimated commands contribution (via interaction matrix), 
+    and then subtracts the applied commands from the projected modes.
+    """
+
+    def __init__(self,
+                 recmat: Recmat = None,
+                 projmat: Recmat = None,
+                 intmat: Intmat = None,
+                 in_commands_size: int = None,
+                 nSlopesToBeDiscarded: int = None,
+                 target_device_idx: int = None,
+                 precision: int = None):
+        super().__init__(target_device_idx=target_device_idx, precision=precision)
+
+        if recmat is None:
+            raise ValueError("Explicit POLC requires a valid recmat.")
+        if intmat is None:
+            raise ValueError("Explicit POLC requires a valid intmat.")
+
+        if nSlopesToBeDiscarded:
+            intmat.reduce_slopes(nSlopesToBeDiscarded)
+
+        self.recmat = recmat
+        self.projmat = projmat
+        self.intmat = intmat
+
+        if in_commands_size is None:
+            in_commands_size = intmat.intmat.shape[1]
+        self.in_commands_size = in_commands_size
+
+        # Properly initialize nmodes based on projmat presence
+        # If no projection matrix is provided, the output size matches the reconstructor
+        if self.projmat is not None:
+            n_out_modes = self.projmat.nmodes
+        else:
+            n_out_modes = self.recmat.nmodes
+
+        # Re-initialize output modes with the correct size
+        self.modes.value = self.xp.zeros(n_out_modes, dtype=self.dtype)
+
+        # Pseudo open-loop modes always match the size of the reconstruction space
+        self.pseudo_ol_modes = BaseValue('output POL modes from explicit POLC',
+                                         target_device_idx=target_device_idx,
+                                         precision=precision)
+        self.pseudo_ol_modes.value = self.xp.zeros(self.recmat.nmodes, dtype=self.dtype)
+
+        self.commands = None  # to be allocated in setup()
+
+        self.inputs['in_commands'] = InputValue(type=BaseValue, optional=True)
+        self.inputs['in_commands_list'] = InputList(type=BaseValue, optional=True)
+
+        self.outputs['out_pseudo_ol_modes'] = self.pseudo_ol_modes
+
+    @classmethod
+    def input_names(cls):
+        # Extend base inputs with command ports
+        inputs = super().input_names()
+        inputs.update({
+            'in_commands': InputDesc(BaseValue,
+                           'Current output command vector for explicit POLC'),
+            'in_commands_list': InputDesc(BaseValue,
+                                'List of current command vectors for explicit POLC (optional)')
+        })
+        return inputs
+
+    @classmethod
+    def output_names(cls):
+        # Extend base outputs with pseudo open-loop modes
+        outputs = super().output_names()
+        outputs.update({
+            'out_pseudo_ol_modes': OutputDesc(BaseValue, 'Pseudo open-loop modal estimate')
+        })
+        return outputs
+
+    def setup(self):
+        super().setup()
+
+        commands = self.local_inputs['in_commands']
+        commands_list = self.local_inputs['in_commands_list']
+
+        if not commands and (not commands_list or not all(commands_list)):
+            raise ValueError("Either 'in_commands' or 'in_commands_list' must be given as an input")
+
+        self.commands = self.xp.zeros(self.in_commands_size, dtype=self.dtype)
+
+    def prepare_trigger(self, t):
+        # Handle slopes via base class
+        super().prepare_trigger(t)
+
+        # Handle commands locally
+        commands = self.local_inputs['in_commands']
+        commands_list = self.local_inputs['in_commands_list']
+
+        if commands is None:
+            # Handle list of commands (e.g. from multiple DMs)
+            self.commands[:] = self.xp.hstack([x.value for x in commands_list])
+        else:
+            if commands.value is None:
+                self.commands[:] = 0.0
+            else:
+                self.commands[:] = commands.value
+
+        # Dimension validation
+        if self.intmat is not None and self.intmat.intmat is not None:
+            expected_slopes_size = self.intmat.intmat.shape[0]
+            if expected_slopes_size != len(self.slopes):
+                raise ValueError(f"Dimension mismatch in POLC mode: "
+                                 f"intmat @ commands will produce {expected_slopes_size} slopes, "
+                                 f"but input slopes has size {len(self.slopes)}")
+
+    def trigger_code(self):
+        # Check refresh based on slopes (standard POLC logic)
+        slopes = self.local_inputs['in_slopes']
+        slopes_list = self.local_inputs['in_slopes_list']
+        slopes_time = slopes.generation_time if slopes is not None else slopes_list[0].generation_time
+
+        if slopes_time != self.current_time:
+            return
+
+        # (1) Compute pseudo open loop modes: R * (s + D * c)
+        comm_slopes = self.intmat.intmat @ self.commands
+        self.pseudo_ol_modes.value[:] = self.recmat.recmat @ (self.slopes + comm_slopes)
+        self.pseudo_ol_modes.generation_time = self.current_time
+
+        # (2) Project to output modes
+        if self.projmat is None:
+            # Avoid aliasing by creating a copy of the array
+            # This ensures that step (3) doesn't modify pseudo_ol_modes.value in-place
+            output_modes = self.pseudo_ol_modes.value.copy()
+        else:
+            output_modes = self.projmat.recmat @ self.pseudo_ol_modes.value
+
+        # (3) Remove the effect of the commands: m_out = P * m_pol - c
+        output_modes -= self.commands
+
+        # Final update with memory-safe assignment
+        self.modes.value[:] = output_modes
+        self.modes.generation_time = self.current_time

--- a/specula/processing_objects/modalrec_explicit_polc.py
+++ b/specula/processing_objects/modalrec_explicit_polc.py
@@ -16,16 +16,13 @@ class ModalrecExplicitPolc(BaseModalrec):
     """
 
     def __init__(self,
-                 recmat: Recmat = None,
+                 recmat: Recmat,
                  projmat: Recmat = None,
                  intmat: Intmat = None,
                  nSlopesToBeDiscarded: int = None,
                  target_device_idx: int = None,
                  precision: int = None):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
-
-        if recmat is None:
-            raise ValueError("Explicit POLC requires a valid recmat.")
 
         self.recmat = recmat
         self.projmat = projmat

--- a/specula/processing_objects/modalrec_explicit_polc.py
+++ b/specula/processing_objects/modalrec_explicit_polc.py
@@ -136,9 +136,10 @@ class ModalrecExplicitPolc(BaseModalrec):
             comm_slopes = self.intmat.intmat @ self.commands
             self.pseudo_ol_modes.value[:] = self.recmat.recmat @ (self.slopes + comm_slopes)
         else:
-            # Se non c'è intmat, usiamo solo gli slope misurati
+            # If no interaction matrix is provided, we assume the pseudo open-loop modes
+            # are just the reconstruction of the measured slopes
             self.pseudo_ol_modes.value[:] = self.recmat.recmat @ self.slopes
-        
+
         self.pseudo_ol_modes.generation_time = self.current_time
 
         # (2) Project to output modes

--- a/specula/processing_objects/modalrec_implicit_polc.py
+++ b/specula/processing_objects/modalrec_implicit_polc.py
@@ -1,112 +1,99 @@
-from specula.processing_objects.modalrec import Modalrec
-from specula.base_processing_obj import InputDesc, OutputDesc
+from specula.processing_objects.base_modalrec import BaseModalrec
 from specula.base_value import BaseValue
-from specula.data_objects.slopes import Slopes
+from specula.connections import InputList, InputValue
+from specula.base_processing_obj import InputDesc
 from specula.data_objects.intmat import Intmat
 from specula.data_objects.recmat import Recmat
 
 
-class ModalrecImplicitPolc(Modalrec):
+class ModalrecImplicitPolc(BaseModalrec):
     """
-    POLC modal reconstructor processing object. Modal reconstruction
-    with implicit Pseudo Open Loop Control (POLC).
-    
-    This class is used to reconstruct the slopes using the implicit POLC method.
-    It uses the command matrix (C = P * R, P projection matrix and R reconstruction
-    matrix) and the H matrix (H = I - C * D, I identity and D interaction matrix)
-    to compute the delta commands.
-    
-    It is typically used in the context of MCAO systems where the reconstruction
-    matrix is defined on virtual DMs on a large number of layers (no. layers > no. real DMs).
-    
-    The implicit POLC method is used to reduce the computational cost of the
-    reconstruction process by using smaller matrices, it also reduces the
-    memory footprint of the reconstruction process (particularly useful
-    for large systems and when using GPUs).
+    POLC modal reconstructor processing object.
+    Uses implicit Pseudo Open Loop Control (POLC) to reduce computational cost.
     """
 
     def __init__(self,
-                 nmodes: int=None,      # TODO =0,
-                 recmat: Recmat=None,
-                 projmat: Recmat=None,
-                 intmat: Intmat=None,
-                 ncutmodes: int=None,
-                 nSlopesToBeDiscarded: int=None,
-                 dmNumber: int=0,
-                 in_commands_size: int=None,
-                 target_device_idx: int=None,
-                 precision: int=None
-                ):
-        super().__init__(
-                 nmodes,
-                 recmat,
-                 projmat,
-                 intmat,
-                 polc=True,
-                 filtmat=None,
-                 identity=False,
-                 ncutmodes=ncutmodes,
-                 nSlopesToBeDiscarded=nSlopesToBeDiscarded,
-                 dmNumber=dmNumber,
-                 noProj=False,
-                 in_commands_size=in_commands_size,
-                 target_device_idx=target_device_idx,
-                 precision=precision)
+                 recmat: Recmat = None,
+                 projmat: Recmat = None,
+                 intmat: Intmat = None,
+                 in_commands_size: int = None,
+                 target_device_idx: int = None,
+                 precision: int = None):
+        super().__init__(target_device_idx=target_device_idx, precision=precision)
 
-        if self.recmat is None or self.recmat.recmat is None:
+        if recmat is None or recmat.recmat is None:
             raise ValueError("Recmat object not valid")
-        if self.projmat is None or self.projmat.recmat is None:
+        if projmat is None or projmat.recmat is None:
             raise ValueError("Projmat object not valid")
-        if self.intmat is None or self.intmat.intmat is None:
+        if intmat is None or intmat.intmat is None:
             raise ValueError("Intmat object not valid")
 
-        # set up the command matrix as the product of the projection matrix
-        # and the reconstruction matrix
-        comm_mat = self.projmat.recmat @ self.recmat.recmat
-        self.comm_mat = Recmat(comm_mat, target_device_idx=target_device_idx, precision=precision)
+        # The effective reconstruction matrix becomes C = P * R
+        comm_mat_arr = projmat.recmat @ recmat.recmat
+        self.recmat = Recmat(comm_mat_arr, target_device_idx=target_device_idx, precision=precision)
 
-        # Now self.recmat and self.projmat can be removed to save memory
-        self.recmat = None
-        self.projmat = None
+        # Set up the H matrix: H = I - C * D
+        h_mat_temp = comm_mat_arr @ intmat.intmat
+        h_mat_arr = self.xp.identity(h_mat_temp.shape[0], dtype=self.dtype) - h_mat_temp
+        self.h_mat = Recmat(h_mat_arr, target_device_idx=target_device_idx, precision=precision)
 
-        # set up the H matrix
-        h_mat_temp = self.comm_mat.recmat @ self.intmat.intmat
-        h_mat = self.xp.identity(h_mat_temp.shape[0], dtype=self.dtype) - h_mat_temp
-        self.h_mat = Recmat(h_mat, target_device_idx=target_device_idx, precision=precision)
+        if in_commands_size is None:
+            in_commands_size = intmat.intmat.shape[1]
+        self.in_commands_size = in_commands_size
 
-        # Now self.intmat can be removed to save memor
-        self.intmat = None
+        nmodes = self.recmat.recmat.shape[0]
+        self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)
+
+        self.commands = None  # to be allocated in setup()
+
+        self.inputs['in_commands'] = InputValue(type=BaseValue, optional=True)
+        self.inputs['in_commands_list'] = InputList(type=BaseValue, optional=True)
 
     @classmethod
     def input_names(cls):
-        return {'in_slopes': InputDesc(Slopes, 'Input wavefront slope vector (optional)'),
-                'in_slopes_list': InputDesc(Slopes, 'List of input slope vectors (optional)'),
-                'in_commands': InputDesc(BaseValue, 'Current output command vector for implicit POLC'),
-                'in_commands_list': InputDesc(BaseValue, 'List of current command vectors for implicit POLC (optional)')}
+        # Merge base inputs with the new command inputs
+        inputs = super().input_names()
+        inputs.update({
+            'in_commands': InputDesc(BaseValue,
+                           'Current output command vector for implicit POLC'),
+            'in_commands_list': InputDesc(BaseValue,
+                                'List of current command vectors for implicit POLC (optional)')
+        })
+        return inputs
 
-    @classmethod
-    def output_names(cls):
-        return {'out_modes': OutputDesc(BaseValue, 'Reconstructed modal command vector'),
-                'out_pseudo_ol_modes': OutputDesc(BaseValue, 'Pseudo open-loop modal estimate')}
+    def setup(self):
+        super().setup()
 
-    def prepare_trigger(self, t):
-        # Call parent's prepare_trigger which handles slopes
-        super().prepare_trigger(t)
-
-        # Handle commands preparation
-        commandsobj = self.local_inputs['in_commands']
+        commands = self.local_inputs['in_commands']
         commands_list = self.local_inputs['in_commands_list']
 
-        # Only update if commands are available
-        if commandsobj is not None and commandsobj.value is not None \
-                                   and commandsobj.value.shape != ():
-            self.commands[:] = self.to_xp(commandsobj.value, dtype=self.dtype)
-        elif commands_list and all(commands_list):
+        if not commands and (not commands_list or not all(commands_list)):
+            raise ValueError("Either 'in_commands' or 'in_commands_list' must be given as an input")
+
+        self.commands = self.xp.zeros(self.in_commands_size, dtype=self.dtype)
+
+    def prepare_trigger(self, t):
+        super().prepare_trigger(t)
+
+        commands = self.local_inputs['in_commands']
+        commands_list = self.local_inputs['in_commands_list']
+
+        if commands is None:
             self.commands[:] = self.xp.hstack([x.value for x in commands_list])
-        # else: keep the zeros from setup() or previous iteration
+        else:
+            if commands.value is None:
+                self.commands[:] = 0.0
+            else:
+                self.commands[:] = commands.value
 
     def trigger_code(self):
+        slopes = self.local_inputs['in_slopes']
+        slopes_list = self.local_inputs['in_slopes_list']
+        slopes_time = slopes.generation_time if slopes is not None else slopes_list[0].generation_time
 
-        output_modes = self.comm_mat.recmat @ self.slopes - self.h_mat.recmat @ self.commands
-        self.modes.value = output_modes
+        if slopes_time != self.current_time:
+            return
+
+        # Memory pre-allocation optimization with self.recmat hosting C
+        self.modes.value[:] = self.recmat.recmat @ self.slopes - self.h_mat.recmat @ self.commands
         self.modes.generation_time = self.current_time

--- a/specula/processing_objects/modalrec_implicit_polc.py
+++ b/specula/processing_objects/modalrec_implicit_polc.py
@@ -45,7 +45,7 @@ class ModalrecImplicitPolc(BaseModalrec):
         inputs = super().input_names()
         inputs.update({
             'in_commands': InputDesc(BaseValue,
-                           'Current output command vector for implicit POLC'),
+                           'Current output command vector for implicit POLC (optional)'),
             'in_commands_list': InputDesc(BaseValue,
                                 'List of current command vectors for implicit POLC (optional)')
         })

--- a/specula/processing_objects/modalrec_implicit_polc.py
+++ b/specula/processing_objects/modalrec_implicit_polc.py
@@ -13,19 +13,12 @@ class ModalrecImplicitPolc(BaseModalrec):
     """
 
     def __init__(self,
-                 recmat: Recmat = None,
-                 projmat: Recmat = None,
-                 intmat: Intmat = None,
+                 recmat: Recmat,
+                 projmat: Recmat,
+                 intmat: Intmat,
                  target_device_idx: int = None,
                  precision: int = None):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
-
-        if recmat is None or recmat.recmat is None:
-            raise ValueError("Recmat object not valid")
-        if projmat is None or projmat.recmat is None:
-            raise ValueError("Projmat object not valid")
-        if intmat is None or intmat.intmat is None:
-            raise ValueError("Intmat object not valid")
 
         # The effective reconstruction matrix becomes C = P * R
         comm_mat_arr = projmat.recmat @ recmat.recmat

--- a/specula/processing_objects/modalrec_implicit_polc.py
+++ b/specula/processing_objects/modalrec_implicit_polc.py
@@ -36,7 +36,7 @@ class ModalrecImplicitPolc(BaseModalrec):
         h_mat_arr = self.xp.identity(h_mat_temp.shape[0], dtype=self.dtype) - h_mat_temp
         self.h_mat = Recmat(h_mat_arr, target_device_idx=target_device_idx, precision=precision)
 
-        self.in_commands_size = intmat.intmat.shape[1]
+        self.in_commands_size = intmat.nmodes
 
         nmodes = self.recmat.recmat.shape[0]
         self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)

--- a/specula/processing_objects/modalrec_implicit_polc.py
+++ b/specula/processing_objects/modalrec_implicit_polc.py
@@ -16,7 +16,6 @@ class ModalrecImplicitPolc(BaseModalrec):
                  recmat: Recmat = None,
                  projmat: Recmat = None,
                  intmat: Intmat = None,
-                 in_commands_size: int = None,
                  target_device_idx: int = None,
                  precision: int = None):
         super().__init__(target_device_idx=target_device_idx, precision=precision)
@@ -37,9 +36,7 @@ class ModalrecImplicitPolc(BaseModalrec):
         h_mat_arr = self.xp.identity(h_mat_temp.shape[0], dtype=self.dtype) - h_mat_temp
         self.h_mat = Recmat(h_mat_arr, target_device_idx=target_device_idx, precision=precision)
 
-        if in_commands_size is None:
-            in_commands_size = intmat.intmat.shape[1]
-        self.in_commands_size = in_commands_size
+        self.in_commands_size = intmat.intmat.shape[1]
 
         nmodes = self.recmat.recmat.shape[0]
         self.modes.value = self.xp.zeros(nmodes, dtype=self.dtype)

--- a/test/params_field_analyser_test.yml
+++ b/test/params_field_analyser_test.yml
@@ -103,7 +103,7 @@ rec:
   recmat_object:      'scao_rec_n8_th0.5'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/test/params_scao_sh_test.yml
+++ b/test/params_scao_sh_test.yml
@@ -104,7 +104,7 @@ rec:
   recmat_object:      'scao_rec_n8_th0.5'         # reconstruction matrix tag
   inputs:
     in_slopes:        'slopec.out_slopes'
-  outputs:  ['out_modes', 'out_pseudo_ol_modes']
+  outputs:  ['out_modes']
 
 
 control:

--- a/test/test_ccd.py
+++ b/test/test_ccd.py
@@ -154,6 +154,3 @@ class TestCCD(unittest.TestCase):
             abs(actual - expected) / expected < rel_tol,
             f"Relative difference {abs(actual - expected) / expected:.2%} exceeds {rel_tol:.2%}"
         )
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_input_output_names.py
+++ b/test/test_input_output_names.py
@@ -57,7 +57,3 @@ class TestInputOutputNames(unittest.TestCase):
                     v, OutputDesc,
                     f"{klass.__name__} output value must be OutputDesc"
                 )
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_modalrec.py
+++ b/test/test_modalrec.py
@@ -4,6 +4,7 @@ specula.init(0)  # Default target device
 import unittest
 
 from specula.processing_objects.modalrec import Modalrec
+from specula.processing_objects.modalrec_explicit_polc import ModalrecExplicitPolc
 from specula.processing_objects.modalrec_implicit_polc import ModalrecImplicitPolc
 from specula.data_objects.recmat import Recmat
 from specula.data_objects.intmat import Intmat
@@ -73,11 +74,10 @@ class TestModalrec(unittest.TestCase):
         commands_ip.generation_time = 0
 
         # Modalrec standard (POLC)
-        rec = Modalrec(
+        rec = ModalrecExplicitPolc(
             recmat=recmat,
             projmat=projmat,
             intmat=intmat,
-            polc=True,
             target_device_idx=target_device_idx
         )
         rec.inputs['in_slopes'].set(slopes)
@@ -127,12 +127,10 @@ class TestModalrec(unittest.TestCase):
         projmat = Recmat(projmat_arr, target_device_idx=target_device_idx)
 
         # Create a Modalrec which expects 6 slopes and 4 commands
-        rec = Modalrec(
-            nmodes=4,
+        rec = ModalrecExplicitPolc(
             recmat=recmat,
             intmat=intmat,
             projmat=projmat,
-            polc=True,
             target_device_idx=target_device_idx
         )
 
@@ -204,19 +202,19 @@ class TestModalrec(unittest.TestCase):
         del projmat
         del recmat
 
-        # Check that original matrices were deleted
-        self.assertIsNone(rec.recmat)
-        self.assertIsNone(rec.projmat)
-        self.assertIsNone(rec.intmat)
-
-        # Check that comm_mat and h_mat exist
-        self.assertIsNotNone(rec.comm_mat)
+        # Check that the merged matrices exist correctly
+        self.assertIsNotNone(rec.recmat) # recmat now hosts C
         self.assertIsNotNone(rec.h_mat)
 
+        # Check that original matrices were never saved as class attributes
+        self.assertFalse(hasattr(rec, 'projmat'))
+        self.assertFalse(hasattr(rec, 'intmat'))
+        self.assertFalse(hasattr(rec, 'comm_mat')) # comm_mat is replaced by recmat
+
         # Verify shapes
-        # comm_mat = projmat @ recmat = (n_modes, n_modes) @ (n_modes, n_slopes)
+        # recmat (which is comm_mat) = projmat @ recmat = (n_modes, n_modes) @ (n_modes, n_slopes)
         #          = (n_modes, n_slopes)
-        self.assertEqual(rec.comm_mat.recmat.shape, (n_modes, n_slopes))
+        self.assertEqual(rec.recmat.recmat.shape, (n_modes, n_slopes))
         # h_mat = I - comm_mat @ intmat = (n_modes, n_modes)
         self.assertEqual(rec.h_mat.recmat.shape, (n_modes, n_modes))
 
@@ -321,8 +319,8 @@ class TestModalrec(unittest.TestCase):
             target_device_idx=target_device_idx
         )
 
-        # comm_mat should be (n_modes, n_slopes)
-        self.assertEqual(rec.comm_mat.recmat.shape, (n_modes, n_slopes))
+        # recmat hosts C, so it should be (n_modes, n_slopes)
+        self.assertEqual(rec.recmat.recmat.shape, (n_modes, n_slopes))
 
         # h_mat should be (n_modes, n_modes)
         self.assertEqual(rec.h_mat.recmat.shape, (n_modes, n_modes))

--- a/test/test_modalrec.py
+++ b/test/test_modalrec.py
@@ -324,3 +324,45 @@ class TestModalrec(unittest.TestCase):
 
         # h_mat should be (n_modes, n_modes)
         self.assertEqual(rec.h_mat.recmat.shape, (n_modes, n_modes))
+
+    @cpu_and_gpu
+    def test_modalrec_explicit_no_intmat(self, target_device_idx, xp):
+        """Test explicit POLC without interaction matrix"""
+
+        # Recmat 4x6, Projmat 4x4 (identity * 2)
+        recmat_arr = xp.random.randn(4, 6)
+        projmat_arr = xp.eye(4) * 2
+
+        recmat = Recmat(recmat_arr, target_device_idx=target_device_idx)
+        projmat = Recmat(projmat_arr, target_device_idx=target_device_idx)
+
+        # Istance of ModalrecExplicitPolc without intmat
+        rec = ModalrecExplicitPolc(
+            recmat=recmat,
+            projmat=projmat,
+            intmat=None,
+            in_commands_size=4,
+            target_device_idx=target_device_idx
+        )
+
+        slopes_arr = xp.random.randn(6)
+        cmd_arr = xp.random.randn(4)
+
+        slopes = Slopes(slopes=slopes_arr, target_device_idx=target_device_idx)
+        commands = BaseValue('commands', value=cmd_arr, target_device_idx=target_device_idx)
+
+        rec.inputs['in_slopes'].set(slopes)
+        rec.inputs['in_commands'].set(commands)
+
+        t = 0
+        slopes.generation_time = t
+        commands.generation_time = t
+
+        rec.setup()
+        rec.prepare_trigger(t)
+        rec.trigger_code()
+
+        # Manual check of math: P @ (R @ s) - c
+        expected = (projmat_arr @ (recmat_arr @ slopes_arr)) - cmd_arr
+
+        xp.testing.assert_allclose(rec.modes.value, expected, rtol=1e-7)

--- a/test/test_modalrec.py
+++ b/test/test_modalrec.py
@@ -341,7 +341,6 @@ class TestModalrec(unittest.TestCase):
             recmat=recmat,
             projmat=projmat,
             intmat=None,
-            in_commands_size=4,
             target_device_idx=target_device_idx
         )
 

--- a/test/test_modalrec.py
+++ b/test/test_modalrec.py
@@ -146,11 +146,9 @@ class TestModalrec(unittest.TestCase):
         slopes.generation_time = t
         commands.generation_time = t
 
-        rec.setup()
-
-        # We expect a ValueError during prepare_trigger due to size mismatch
+        # We expect a ValueError during setup due to size mismatch
         with self.assertRaises(ValueError) as cm:
-            rec.prepare_trigger(t)
+            rec.setup()
 
         # Verify that the error message is as expected
         self.assertIn("Dimension mismatch in POLC mode", str(cm.exception))

--- a/test/test_modalrec.py
+++ b/test/test_modalrec.py
@@ -366,3 +366,66 @@ class TestModalrec(unittest.TestCase):
         expected = (projmat_arr @ (recmat_arr @ slopes_arr)) - cmd_arr
 
         xp.testing.assert_allclose(rec.modes.value, expected, rtol=1e-7)
+
+    @cpu_and_gpu
+    def test_modalrec_explicit_no_projmat_and_aliasing(self, target_device_idx, xp):
+        """
+        Test explicit POLC without a projection matrix, and verify the memory 
+        aliasing fix (preventing pseudo_ol_modes from being modified in-place).
+        """
+
+        # Dimensions: 4 modes, 6 slopes
+        recmat_arr = xp.random.randn(4, 6)
+        intmat_arr = xp.random.randn(6, 4)
+
+        recmat = Recmat(recmat_arr, target_device_idx=target_device_idx)
+        intmat = Intmat(intmat_arr, target_device_idx=target_device_idx)
+
+        # Initialize without projmat! This triggers the internal use of .copy()
+        rec = ModalrecExplicitPolc(
+            recmat=recmat,
+            projmat=None,
+            intmat=intmat,
+            target_device_idx=target_device_idx
+        )
+
+        # Controlled input arrays. We use non-zero numbers so the subtraction 
+        # actually changes the values, making the aliasing test effective.
+        slopes_arr = xp.ones(6, dtype=xp.float32) * 2.0
+        cmd_arr = xp.ones(4, dtype=xp.float32) * 0.5
+
+        slopes = Slopes(slopes=slopes_arr, target_device_idx=target_device_idx)
+        commands = BaseValue('commands', value=cmd_arr, target_device_idx=target_device_idx)
+
+        slopes.generation_time = 0
+        commands.generation_time = 0
+
+        rec.inputs['in_slopes'].set(slopes)
+        rec.inputs['in_commands'].set(commands)
+
+        loop = LoopControl()
+        loop.add(rec, idx=0)
+        loop.run(dt=1, run_time=1)
+
+        # -- MATH AND ALIASING VERIFICATION --
+
+        # 1. Expected calculation for pseudo open-loop: R @ (s + D @ c)
+        expected_pseudo = recmat_arr @ (slopes_arr + intmat_arr @ cmd_arr)
+
+        # 2. Expected calculation for output: pseudo_ol_modes - c
+        # (without P, it is a simple subtraction)
+        expected_out = expected_pseudo - cmd_arr
+
+        # Test 1: Are the pseudo open loop modes intact?
+        # If the .copy() fix were missing, this test would fail because expected_pseudo
+        # would undergo the commands subtraction due to the memory reference.
+        xp.testing.assert_allclose(rec.pseudo_ol_modes.value, expected_pseudo, rtol=1e-5)
+
+        # Test 2: Is the final output correct?
+        xp.testing.assert_allclose(rec.modes.value, expected_out, rtol=1e-5)
+
+        # Test 3: Absolute guarantee against aliasing
+        # Ensure that the two arrays in memory are actually different
+        # (since the commands are not zero)
+        with self.assertRaises(AssertionError):
+            xp.testing.assert_allclose(rec.pseudo_ol_modes.value, rec.modes.value)

--- a/test/test_multi_im_calibrator.py
+++ b/test/test_multi_im_calibrator.py
@@ -829,6 +829,3 @@ class TestMultiImCalibrator(unittest.TestCase):
         self.assertEqual(calibrator.count_commands[1][0], 3)  # Mode 0, input 1 (from cmd1)
         self.assertEqual(calibrator.count_commands[1][1], 0)  # Mode 1, input 1 (no comand)
         self.assertEqual(calibrator.count_commands[1][2], 3)  # Mode 2, input 1 (from cmd2)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_multi_rec_calibrator.py
+++ b/test/test_multi_rec_calibrator.py
@@ -495,7 +495,3 @@ class TestMultiRecCalibrator(unittest.TestCase):
                 # Should not raise any errors
                 calibrator.setup()
                 # No assertion needed - just checking it doesn't raise an error
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Regarding the idea of creating a separate class just for the POLC step (computing pseudo-slopes) and passing them to a pure Reconstructor, I decided against it for the following reasons:

- The core advantage of the implicit POLC is fusing the matrices during setup (`comm_mat_arr = projmat.recmat @ recmat.recmat`  and `h_mat_temp = comm_mat_arr @ intmat.intmat`) and dropping the original ones to save memory and computations. If we split POLC and Reconstruction into two separate objects, they can't mathematically fuse their matrices.

- Two separate objects mean making an additional MVM in case of explicit POLC. I’m referring to: `self.pseudo_ol_modes.value[:] = self.recmat.recmat @ (self.slopes + comm_slopes)`