### PR TITLE
(GA) removed ifunc cuts in ModalAnalysis

### DIFF
--- a/specula/data_objects/ifunc.py
+++ b/specula/data_objects/ifunc.py
@@ -131,6 +131,12 @@ class IFunc(BaseDataObj):
     def size(self):
         return self._influence_function.shape
 
+    def nmodes(self):
+        return self._influence_function.shape[0]
+
+    def npoints(self):
+        return self._influence_function.shape[1]
+
     @property
     def type(self):
         return self._influence_function.dtype
@@ -167,7 +173,7 @@ class IFunc(BaseDataObj):
 
     def inverse(self, nmodes=None):
         ifunc = self._influence_function
-        if nmodes is not None and nmodes != ifunc.shape[0]:
+        if nmodes is not None and nmodes != self.nmodes():
             ifunc = cut_modes(ifunc, nmodes=nmodes)
 
         inv = self.xp.linalg.pinv(ifunc)

--- a/specula/data_objects/ifunc.py
+++ b/specula/data_objects/ifunc.py
@@ -165,8 +165,12 @@ class IFunc(BaseDataObj):
 
         return ifunc_3d
 
-    def inverse(self):
-        inv = self.xp.linalg.pinv(self._influence_function)
+    def inverse(self, nmodes=None):
+        ifunc = self._influence_function
+        if nmodes is not None and nmodes != ifunc.shape[0]:
+            ifunc = cut_modes(ifunc, nmodes=nmodes)
+
+        inv = self.xp.linalg.pinv(ifunc)
         return IFuncInv(inv, mask=self._mask_inf_func, precision=self.precision, target_device_idx=self.target_device_idx)
 
     @staticmethod

--- a/specula/data_objects/ifunc_inv.py
+++ b/specula/data_objects/ifunc_inv.py
@@ -76,6 +76,12 @@ class IFuncInv(BaseDataObj):
     def size(self):
         return self.ifunc_inv.shape
 
+    def nmodes(self):
+        return self.ifunc_inv.shape[1]
+
+    def npoints(self):
+        return self.ifunc_inv.shape[0]
+
     def get_fits_header(self):
         hdr = fits.Header()
         hdr['VERSION'] = 1

--- a/specula/processing_objects/dm.py
+++ b/specula/processing_objects/dm.py
@@ -117,7 +117,7 @@ class DM(BaseProcessingObj):
         if start_mode is None:
             start_mode = 0
         if nmodes is None:
-            nmodes = self._ifunc.size[0]
+            nmodes = self._ifunc.nmodes()
 
         if idx_modes is not None:
             self._valid_modes = idx_modes
@@ -135,7 +135,7 @@ class DM(BaseProcessingObj):
             self.m2c_commands = None
         
         s = self._ifunc.mask_inf_func.shape
-        nmodes_if = self._ifunc.size[0]
+        nmodes_if = self._ifunc.nmodes()
         self.if_commands = self.xp.zeros(nmodes_if, dtype=self.dtype)
 
         self.if_commands_selector = slice(0, self.n_valid_modes)

--- a/specula/processing_objects/modal_analysis.py
+++ b/specula/processing_objects/modal_analysis.py
@@ -56,7 +56,7 @@ class ModalAnalysis(BaseProcessingObj):
             self.phase2modes = ifunc.inverse()
         elif ifunc is None and ifunc_inv is not None:
             # Use ifunc_inv directly, don't attempt to call inverse() on None
-            if nmodes is not None and nmodes != ifunc_inv.size[0]:
+            if nmodes != ifunc_inv.nmodes():
                 ifunc_inv = IFuncInv(ifunc_inv.ifunc_inv[:, :nmodes],
                                      mask=ifunc_inv.mask_inf_func,
                                      target_device_idx=ifunc_inv.target_device_idx,
@@ -77,7 +77,7 @@ class ModalAnalysis(BaseProcessingObj):
         self.wavelengthInNm = wavelengthInNm
 
         if nmodes is None:
-            self._n_modes = self.phase2modes.size[1]
+            self._n_modes = self.phase2modes.nmodes()
         else:
             self._n_modes = nmodes
         self._n_inputs = n_inputs

--- a/specula/processing_objects/modal_analysis.py
+++ b/specula/processing_objects/modal_analysis.py
@@ -57,13 +57,14 @@ class ModalAnalysis(BaseProcessingObj):
         elif ifunc is None and ifunc_inv is not None:
             # Use ifunc_inv directly, don't attempt to call inverse() on None
             if nmodes is not None and nmodes != ifunc_inv.size[0]:
-                ifunc_inv.cut(nmodes=nmodes)
+                ifunc_inv = IFuncInv(ifunc_inv.ifunc_inv[:, :nmodes],
+                                     mask=ifunc_inv.mask_inf_func,
+                                     target_device_idx=ifunc_inv.target_device_idx,
+                                     precision=ifunc_inv.precision)
             self.phase2modes = ifunc_inv
         elif ifunc is not None and ifunc_inv is None:
             # This is the case where only ifunc is provided
-            if nmodes is not None and nmodes != ifunc.size[0]:
-                ifunc.cut(nmodes=nmodes)
-            self.phase2modes = ifunc.inverse()
+            self.phase2modes = ifunc.inverse(nmodes=nmodes)
         else:  # Both are provided
             # Prioritize ifunc_inv
             self.phase2modes = ifunc_inv

--- a/test/test_ifunc.py
+++ b/test/test_ifunc.py
@@ -79,6 +79,16 @@ class TestIFunv(unittest.TestCase):
         np.testing.assert_array_equal(idx1[1], idx2[1])
 
     @cpu_and_gpu
+    def test_inverse_with_nmodes_does_not_mutate_original(self, target_device_idx, xp):
+        ifunc = IFunc(self.data, mask=self.mask, target_device_idx=target_device_idx)
+        original_shape = ifunc.size
+
+        inv = ifunc.inverse(nmodes=1)
+
+        self.assertEqual(ifunc.size, original_shape)
+        self.assertEqual(inv.size, (self.data.shape[1], 1))
+
+    @cpu_and_gpu
     def test_ifunc_2d_to_3d(self, target_device_idx, xp):
         '''Test for ifunc_2d_to_3d method'''
         mask = make_mask(64)

--- a/test/test_ifunc.py
+++ b/test/test_ifunc.py
@@ -89,6 +89,13 @@ class TestIFunv(unittest.TestCase):
         self.assertEqual(inv.size, (self.data.shape[1], 1))
 
     @cpu_and_gpu
+    def test_nmodes_and_npoints(self, target_device_idx, xp):
+        ifunc = IFunc(self.data, mask=self.mask, target_device_idx=target_device_idx)
+
+        self.assertEqual(ifunc.nmodes(), self.data.shape[0])
+        self.assertEqual(ifunc.npoints(), self.data.shape[1])
+
+    @cpu_and_gpu
     def test_ifunc_2d_to_3d(self, target_device_idx, xp):
         '''Test for ifunc_2d_to_3d method'''
         mask = make_mask(64)

--- a/test/test_ifunc_inv.py
+++ b/test/test_ifunc_inv.py
@@ -37,6 +37,15 @@ class TestIFuncInv(unittest.TestCase):
         self.assertEqual(obj.size, self.shape)
 
     @cpu_and_gpu
+    def test_nmodes_and_npoints(self, target_device_idx, xp):
+        ifunc_inv = xp.random.rand(*self.shape).astype(xp.float32)
+        mask = xp.random.choice([0, 1], size=self.shape).astype(xp.uint8)
+        obj = IFuncInv(ifunc_inv, mask, target_device_idx=target_device_idx)
+
+        self.assertEqual(obj.npoints(), self.shape[0])
+        self.assertEqual(obj.nmodes(), self.shape[1])
+
+    @cpu_and_gpu
     def test_get_value(self, target_device_idx, xp):
         ifunc_inv = xp.random.rand(*self.shape).astype(xp.float32)
         mask = xp.random.choice([0, 1], size=self.shape).astype(xp.uint8)

--- a/test/test_modal_analysis_unwrapping.py
+++ b/test/test_modal_analysis_unwrapping.py
@@ -153,3 +153,19 @@ class TestModalAnalysisUnwrapping(unittest.TestCase):
 
         self.assertEqual(ifunc_inv.size, original_shape)
         self.assertEqual(modal_analysis.phase2modes.size, (4, 2))
+
+    @cpu_and_gpu
+    def test_modal_analysis_ifunc_inv_nmodes_none_shares_ifunc_inv_data(self, target_device_idx, xp):
+        ifunc_inv_data = xp.random.rand(4, 3).astype(xp.float32)
+        mask = xp.ones((2, 2), dtype=xp.uint8)
+        ifunc_inv = IFuncInv(ifunc_inv_data, mask,
+                             target_device_idx=target_device_idx)
+
+        modal_analysis = ModalAnalysis(ifunc_inv=ifunc_inv, nmodes=None,
+                                       target_device_idx=target_device_idx)
+
+        phase2modes_data = modal_analysis.phase2modes.ifunc_inv
+        if hasattr(xp, 'may_share_memory'):
+            self.assertTrue(xp.may_share_memory(phase2modes_data, ifunc_inv_data))
+        else:
+            self.assertEqual(phase2modes_data.data.ptr, ifunc_inv_data.data.ptr)

--- a/test/test_modal_analysis_unwrapping.py
+++ b/test/test_modal_analysis_unwrapping.py
@@ -13,6 +13,7 @@ from specula.processing_objects.wave_generator import WaveGenerator
 from specula.processing_objects.atmo_infinite_evolution import AtmoInfiniteEvolution
 from specula.processing_objects.atmo_propagation import AtmoPropagation
 from specula.processing_objects.modal_analysis import ModalAnalysis
+from specula.data_objects.ifunc_inv import IFuncInv
 from specula.data_objects.simul_params import SimulParams
 from test.specula_testlib import cpu_and_gpu
 from skimage.restoration import unwrap_phase
@@ -138,3 +139,17 @@ class TestModalAnalysisUnwrapping(unittest.TestCase):
         # floating-point differences on single modal coefficients.
         rel_error = np.linalg.norm(modes_phys - modes_geom) / np.linalg.norm(modes_geom)
         np.testing.assert_array_less(rel_error, 0.16)
+
+    @cpu_and_gpu
+    def test_modal_analysis_ifunc_inv_nmodes_does_not_mutate_input(self, target_device_idx, xp):
+        ifunc_inv_data = xp.random.rand(4, 3).astype(xp.float32)
+        mask = xp.ones((2, 2), dtype=xp.uint8)
+        ifunc_inv = IFuncInv(ifunc_inv_data, mask,
+                             target_device_idx=target_device_idx)
+        original_shape = ifunc_inv.size
+
+        modal_analysis = ModalAnalysis(ifunc_inv=ifunc_inv, nmodes=2,
+                                       target_device_idx=target_device_idx)
+
+        self.assertEqual(ifunc_inv.size, original_shape)
+        self.assertEqual(modal_analysis.phase2modes.size, (4, 2))


### PR DESCRIPTION
ifunc.cut(nmodes=nmodes) modifies the object in place, so reusing the same instance elsewhere would also reflect the truncation.
This pull request changes the behaviour to prevent this from happening.