### PR TITLE
Removed duplicate input_names definitions

### DIFF
--- a/specula/base_processing_obj.py
+++ b/specula/base_processing_obj.py
@@ -362,7 +362,7 @@ class BaseProcessingObj(BaseTimeObj):
                 raise TypeError(f"Input {input_name} must be an InputValue or an InputList")
 
             expected_type = declared_desc[0]
-            if input_obj.output_ref_type is not expected_type:
+            if input_obj.type is not expected_type:
                 raise TypeError(
                     f"Input {input_name} must be of type {expected_type}, "
                     f"but got {input_obj.type}"

--- a/specula/connections.py
+++ b/specula/connections.py
@@ -59,7 +59,7 @@ class _InputItem():
             if not isinstance(value, type_):
                 raise ValueError(f'Value must be of type {type_} instead of {type(value)}')
 
-        self.output_ref_type = type_
+        self.type = type_
         self.cloned_value = None
         self.optional = optional
         self.remote_rank = remote_rank
@@ -70,7 +70,7 @@ class _InputItem():
 
     def receive_new_value(self, first_mpi_receive=True):
         self.logger.mpi_send_debug(
-                               f'RECV from rank {self.remote_rank} {self.tag=} type={self.output_ref_type})'
+                               f'RECV from rank {self.remote_rank} {self.tag=} type={self.type})'
                                )
         if first_mpi_receive or self.cloned_value.get_value() is None:
             self.logger.mpi_send_debug(f'recv with Pickle tag={self.tag}')
@@ -126,7 +126,7 @@ class InputList():
         perform its own MPI receive if needed. This allows to mix in the same list
         inputs with different sources (useful e.g. in propagation)
         """
-        self.output_ref_type = type
+        self.type = type
         self.input_values = []
         self.optional = optional
         self.requesting_obj_name = None
@@ -152,10 +152,10 @@ class InputList():
                 self.append(v, remote_rank, tag)
             return
 
-        if not isinstance(item, self.output_ref_type) and remote_rank is None:
-            raise ValueError(f'Item must be of type {self.output_ref_type} instead of {type(item)}')
+        if not isinstance(item, self.type) and remote_rank is None:
+            raise ValueError(f'Item must be of type {self.type} instead of {type(item)}')
 
-        self.input_values.append(_InputItem(self.output_ref_type,
+        self.input_values.append(_InputItem(self.type,
                                             item,
                                             remote_rank=remote_rank,
                                             tag=tag,
@@ -186,5 +186,5 @@ class InputValue(InputList):
                 obj_info = f" (from {self.requesting_obj_name}.{self.input_name})" \
                            if self.requesting_obj_name else ""
                 raise ValueError(f'Input {self.input_name} of object {self.requesting_obj_name} is empty and not optional. '
-                                 f'Input type: {self.output_ref_type}{obj_info}')
+                                 f'Input type: {self.type}{obj_info}')
         return values_list[0]

--- a/specula/processing_objects/ciao_ciao_slopec.py
+++ b/specula/processing_objects/ciao_ciao_slopec.py
@@ -74,14 +74,11 @@ class CiaoCiaoSlopec(Slopec):
 
     @classmethod
     def input_names(cls):
-        return {'in_pixels': InputDesc(Pixels, 'Input interferogram pixel data from detector')}
+        return super().input_names()
 
     @classmethod
     def output_names(cls):
-        return {'out_slopes': OutputDesc(Slopes, 'Computed OPD map as a flattened slope vector'),
-                'out_flux_per_subaperture': OutputDesc(BaseValue, 'Mean flux per pixel within the pupil mask'),
-                'out_total_counts': OutputDesc(BaseValue, 'Total photon counts'),
-                'out_subap_counts': OutputDesc(BaseValue, 'Counts per subaperture')}
+        return super().output_names()
 
     def nsubaps(self):
         return 1

--- a/specula/processing_objects/ciao_ciao_slopec.py
+++ b/specula/processing_objects/ciao_ciao_slopec.py
@@ -1,10 +1,7 @@
 from specula import cpuArray
 from specula.lib.interp2d import Interp2D
-from specula.data_objects.pixels import Pixels
 from specula.data_objects.pupilstop import Pupilstop
 from specula.processing_objects.slopec import Slopec
-from specula.base_processing_obj import InputDesc, OutputDesc
-from specula.base_value import BaseValue
 from specula.data_objects.slopes import Slopes
 from skimage.restoration import unwrap_phase
 

--- a/specula/processing_objects/distributed_sh.py
+++ b/specula/processing_objects/distributed_sh.py
@@ -63,11 +63,11 @@ class DistributedSH(SH):
 
     @classmethod
     def input_names(cls):
-        return {'in_ef': InputDesc(ElectricField, 'Input electric field from the telescope pupil')}
+        return super().input_names()
 
     @classmethod
     def output_names(cls):
-        return {'out_i': OutputDesc(Intensity, 'Output intensity on the detector (Shack-Hartmann spot pattern)')}
+        return super().output_names()
 
     def setup(self):
         '''

--- a/specula/processing_objects/distributed_sh.py
+++ b/specula/processing_objects/distributed_sh.py
@@ -1,8 +1,6 @@
 import copy
 
-from specula.base_processing_obj import BaseProcessingObj, InputDesc, OutputDesc
-from specula.data_objects.electric_field import ElectricField
-from specula.data_objects.intensity import Intensity
+from specula.base_processing_obj import BaseProcessingObj
 from specula.data_objects.laser_launch_telescope import LaserLaunchTelescope
 from specula.processing_objects.sh import SH
 from specula import cp

--- a/specula/processing_objects/double_roof_slopec.py
+++ b/specula/processing_objects/double_roof_slopec.py
@@ -1,7 +1,4 @@
 from specula.processing_objects.pyr_slopec import PyrSlopec
-from specula.base_processing_obj import InputDesc, OutputDesc
-from specula.base_value import BaseValue
-from specula.data_objects.pixels import Pixels
 from specula.data_objects.pupdata import PupData
 from specula.data_objects.slopes import Slopes
 

--- a/specula/processing_objects/double_roof_slopec.py
+++ b/specula/processing_objects/double_roof_slopec.py
@@ -35,15 +35,11 @@ class DoubleRoofSlopec(PyrSlopec):
 
     @classmethod
     def input_names(cls):
-        return {'in_pixels': InputDesc(Pixels, 'Input pixel data from the double-roof wavefront sensor detector')}
+        return super().input_names()
 
     @classmethod
     def output_names(cls):
-        return {'out_slopes': OutputDesc(Slopes, 'Computed wavefront slopes'),
-                'out_flux_per_subaperture': OutputDesc(BaseValue, 'Flux per subaperture'),
-                'out_total_counts': OutputDesc(BaseValue, 'Total photon counts'),
-                'out_subap_counts': OutputDesc(BaseValue, 'Counts per subaperture'),
-                'out_pupdata': OutputDesc(PupData, 'Pupil data with subaperture geometry')}
+        return super().output_names()
 
     def _compute_pyr_slopes(self, A, B, C, D, factor):
 

--- a/specula/processing_objects/dynamic_pyr_pupdata_calibrator.py
+++ b/specula/processing_objects/dynamic_pyr_pupdata_calibrator.py
@@ -3,9 +3,6 @@
 from specula.base_value import BaseValue
 from specula.base_processing_obj import InputDesc, OutputDesc
 from specula.connections import InputValue
-from specula.data_objects.intensity import Intensity
-from specula.data_objects.pixels import Pixels
-from specula.data_objects.pupdata import PupData
 from specula.processing_objects.pyr_pupdata_calibrator import PyrPupdataCalibrator
 from specula.scalar_values import IntValue, StringValue, FloatValue
 

--- a/specula/processing_objects/dynamic_pyr_pupdata_calibrator.py
+++ b/specula/processing_objects/dynamic_pyr_pupdata_calibrator.py
@@ -106,11 +106,11 @@ class DynamicPyrPupdataCalibrator(PyrPupdataCalibrator):
     def input_names(cls):
         result = super().input_names()
         result.update({
-                'in_save': InputDesc(BaseValue, 'Trigger to save the current calibration data (optional)'),
-                'in_dt': InputDesc(BaseValue, 'Dynamically update the time step in seconds (optional)'),
-                'in_thr1': InputDesc(BaseValue, 'Dynamically update the first threshold (optional)'),
-                'in_thr2': InputDesc(BaseValue, 'Dynamically update the second threshold (optional)'),
-                'in_output_tag': InputDesc(BaseValue, 'Dynamically update the output tag (optional)')
+                'in_save': InputDesc(IntValue, 'Trigger to save the current calibration data (optional)'),
+                'in_dt': InputDesc(FloatValue, 'Dynamically update the time step in seconds (optional)'),
+                'in_thr1': InputDesc(FloatValue, 'Dynamically update the first threshold (optional)'),
+                'in_thr2': InputDesc(FloatValue, 'Dynamically update the second threshold (optional)'),
+                'in_output_tag': InputDesc(StringValue, 'Dynamically update the output tag (optional)')
                 })
         return result
 
@@ -118,7 +118,7 @@ class DynamicPyrPupdataCalibrator(PyrPupdataCalibrator):
     def output_names(cls):
         result = super().output_names()
         result.update({
-                'out_params': OutputDesc(BaseValue, 'Dictionary with current calibration parameters and status')
+                'out_params': OutputDesc(StringValue, 'Dictionary with current calibration parameters and status')
                 })
         return result
 

--- a/specula/processing_objects/dynamic_pyr_pupdata_calibrator.py
+++ b/specula/processing_objects/dynamic_pyr_pupdata_calibrator.py
@@ -107,18 +107,23 @@ class DynamicPyrPupdataCalibrator(PyrPupdataCalibrator):
 
     @classmethod
     def input_names(cls):
-        return {'in_i': InputDesc(Intensity, 'Input intensity from the pyramid WFS detector (optional)'),
-                'in_pixels': InputDesc(Pixels, 'Input pixel data from the detector (optional)'),
-                'in_save': InputDesc(IntValue, 'Trigger to save the current calibration data (optional)'),
-                'in_dt': InputDesc(FloatValue, 'Dynamically update the time step in seconds (optional)'),
-                'in_thr1': InputDesc(FloatValue, 'Dynamically update the first threshold (optional)'),
-                'in_thr2': InputDesc(FloatValue, 'Dynamically update the second threshold (optional)'),
-                'in_output_tag': InputDesc(StringValue, 'Dynamically update the output tag (optional)')}
+        result = super().input_names()
+        result.update({
+                'in_save': InputDesc(BaseValue, 'Trigger to save the current calibration data (optional)'),
+                'in_dt': InputDesc(BaseValue, 'Dynamically update the time step in seconds (optional)'),
+                'in_thr1': InputDesc(BaseValue, 'Dynamically update the first threshold (optional)'),
+                'in_thr2': InputDesc(BaseValue, 'Dynamically update the second threshold (optional)'),
+                'in_output_tag': InputDesc(BaseValue, 'Dynamically update the output tag (optional)')
+                })
+        return result
 
     @classmethod
     def output_names(cls):
-        return {'out_pupdata': OutputDesc(PupData, 'Calibrated pupil data with subaperture geometry'),
-                'out_params': OutputDesc(StringValue, 'Multi-line string with current calibration parameters and status')}
+        result = super().output_names()
+        result.update({
+                'out_params': OutputDesc(BaseValue, 'Dictionary with current calibration parameters and status')
+                })
+        return result
 
     def prepare_trigger(self, t):
         super().prepare_trigger(t)

--- a/specula/processing_objects/focal_plane_filter.py
+++ b/specula/processing_objects/focal_plane_filter.py
@@ -39,7 +39,7 @@ class FocalPlaneFilter(Coronagraph):
 
     @classmethod
     def output_names(cls):
-        return {'out_ef': OutputDesc(ElectricField, 'Output electric field after focal plane filter mask application')}
+        return super().output_names()
 
     def make_pupil_plane_mask(self):
         return 1.0

--- a/specula/processing_objects/focal_plane_filter.py
+++ b/specula/processing_objects/focal_plane_filter.py
@@ -1,6 +1,4 @@
 from specula import RAD2ASEC
-from specula.base_processing_obj import OutputDesc
-from specula.data_objects.electric_field import ElectricField
 from specula.lib.make_mask import make_mask
 from specula.data_objects.simul_params import SimulParams
 from specula.processing_objects.abstract_coronagraph import Coronagraph

--- a/specula/processing_objects/four_quadrant_coronagraph.py
+++ b/specula/processing_objects/four_quadrant_coronagraph.py
@@ -45,7 +45,7 @@ class FourQuadrantCoronagraph(Coronagraph):
 
     @classmethod
     def output_names(cls):
-        return {'out_ef': OutputDesc(ElectricField, 'Output electric field after four-quadrant coronagraph mask application')}
+        return super().output_names()
 
     def make_focal_plane_mask(self):
         """ Make a quadrant mask, where 2 opposite quadrants apply a pi phase delay """

--- a/specula/processing_objects/four_quadrant_coronagraph.py
+++ b/specula/processing_objects/four_quadrant_coronagraph.py
@@ -1,6 +1,4 @@
 from specula.processing_objects.abstract_coronagraph import Coronagraph
-from specula.base_processing_obj import OutputDesc
-from specula.data_objects.electric_field import ElectricField
 from specula.data_objects.simul_params import SimulParams
 from specula.lib.make_mask import make_mask
 from specula import RAD2ASEC, np

--- a/specula/processing_objects/lyot_coronagraph.py
+++ b/specula/processing_objects/lyot_coronagraph.py
@@ -1,6 +1,4 @@
 from specula.processing_objects.abstract_coronagraph import Coronagraph
-from specula.base_processing_obj import OutputDesc
-from specula.data_objects.electric_field import ElectricField
 from specula.data_objects.simul_params import SimulParams
 from specula.lib.make_mask import make_mask
 from specula import RAD2ASEC

--- a/specula/processing_objects/lyot_coronagraph.py
+++ b/specula/processing_objects/lyot_coronagraph.py
@@ -58,7 +58,7 @@ class LyotCoronagraph(Coronagraph):
 
     @classmethod
     def output_names(cls):
-        return {'out_ef': OutputDesc(ElectricField, 'Output electric field after Lyot coronagraph mask application')}
+        return super().output_names()
 
     def make_focal_plane_mask(self):
         # Mask centered on the crosshair between 4 pixels

--- a/test/test_multi_rec_calibrator.py
+++ b/test/test_multi_rec_calibrator.py
@@ -329,8 +329,8 @@ class TestMultiRecCalibrator(unittest.TestCase):
         intmat_list_input = calibrator.inputs['intmat_list']
         full_intmat_input = calibrator.inputs['full_intmat']
         
-        self.assertEqual(intmat_list_input.output_ref_type, Intmat)
-        self.assertEqual(full_intmat_input.output_ref_type, Intmat)
+        self.assertEqual(intmat_list_input.type, Intmat)
+        self.assertEqual(full_intmat_input.type, Intmat)
 
     def test_precision_handling(self):
         """Test that precision is properly handled"""

--- a/test/test_mvm.py
+++ b/test/test_mvm.py
@@ -74,31 +74,6 @@ class TestMVM(unittest.TestCase):
         self.assertIn("got 5, expected 4", str(cm.exception))
 
     @cpu_and_gpu
-    def test_mvm_null_recmat(self, target_device_idx, xp):
-        """Test MVM behavior with null reconstruction matrix"""
-        # Create recmat with None matrix
-        # Create a valid matrix first, then set it to None after
-        matrix = xp.eye(3)
-        recmat = Recmat(matrix, target_device_idx=target_device_idx)
-        mvm = MVM(recmat=recmat, target_device_idx=target_device_idx)
-        
-        # Now set the internal matrix to None to test the warning
-        mvm.recmat.recmat = None
-
-        # This should work during initialization but skip during trigger_code
-        input_vector = xp.array([1, 2, 3], dtype=xp.float64)
-        input_value = BaseValue('test input', value=input_vector,
-                                target_device_idx=target_device_idx)
-
-        mvm.inputs['in_vector'].set(input_value)
-
-        # Should not raise during trigger_code, just print warning
-        mvm.trigger_code()
-
-        # Output should remain zeros (initial allocation)
-        self.assertTrue(xp.allclose(mvm.output.value, 0))
-
-    @cpu_and_gpu
     def test_mvm_no_input_provided(self, target_device_idx, xp):
         """Test that MVM raises error when no input is provided"""
         matrix = xp.eye(3)

--- a/test/test_mvm.py
+++ b/test/test_mvm.py
@@ -74,6 +74,31 @@ class TestMVM(unittest.TestCase):
         self.assertIn("got 5, expected 4", str(cm.exception))
 
     @cpu_and_gpu
+    def test_mvm_null_recmat(self, target_device_idx, xp):
+        """Test MVM behavior with null reconstruction matrix"""
+        # Create recmat with None matrix
+        # Create a valid matrix first, then set it to None after
+        matrix = xp.eye(3)
+        recmat = Recmat(matrix, target_device_idx=target_device_idx)
+        mvm = MVM(recmat=recmat, target_device_idx=target_device_idx)
+        
+        # Now set the internal matrix to None to test the warning
+        mvm.recmat.recmat = None
+
+        # This should work during initialization but skip during trigger_code
+        input_vector = xp.array([1, 2, 3], dtype=xp.float64)
+        input_value = BaseValue('test input', value=input_vector,
+                                target_device_idx=target_device_idx)
+
+        mvm.inputs['in_vector'].set(input_value)
+
+        # Should not raise during trigger_code, just print warning
+        mvm.trigger_code()
+
+        # Output should remain zeros (initial allocation)
+        self.assertTrue(xp.allclose(mvm.output.value, 0))
+
+    @cpu_and_gpu
     def test_mvm_no_input_provided(self, target_device_idx, xp):
         """Test that MVM raises error when no input is provided"""
         matrix = xp.eye(3)

--- a/test/test_rec_calibrator.py
+++ b/test/test_rec_calibrator.py
@@ -234,7 +234,7 @@ class TestRecCalibrator(unittest.TestCase):
         # Check that in_intmat input is properly configured
         self.assertIn('in_intmat', calibrator.inputs)
         input_value = calibrator.inputs['in_intmat']
-        self.assertEqual(input_value.output_ref_type, Intmat)
+        self.assertEqual(input_value.type, Intmat)
 
     def test_inheritance_from_base_processing_obj(self):
         """Test that RecCalibrator properly inherits from BaseProcessingObj"""


### PR DESCRIPTION
Removed input_names() and output_names() declarations in derived classes, where the parent class already defines them: the derived class only defines additional inputs and outputs, if any