### PR TITLE
Avoid duplicate logging initializations

### DIFF
--- a/specula/log.py
+++ b/specula/log.py
@@ -52,6 +52,12 @@ def init_logging(log_level=logging.INFO, process_rank=None):
 
     logging_initialized = True
 
+
+def reset_logging():
+    global logging_initialized
+    logging_initialized = False
+
+
 class SpeculaLogFilter(logging.Filter):
     '''
     Add the process rank to the log record, if defined.

--- a/specula/log.py
+++ b/specula/log.py
@@ -12,6 +12,8 @@ MPI_SEND_DBG_LEVEL = 5
 logging.addLevelName(MPI_DBG_LEVEL, 'MPI_DBG')
 logging.addLevelName(MPI_SEND_DBG_LEVEL, 'MPI_SEND_DBG')
 
+logging_initialized = False
+
 
 def get_specula_logger(name):
     '''
@@ -27,6 +29,9 @@ def init_logging(log_level=logging.INFO, process_rank=None):
     Initialize logging with a custom format that includes the process rank if provided,
     and set up logging with our SpeculaLogFilter enabled.
     '''
+    global logging_initialized
+    if logging_initialized:
+        return
 
     formatter = SpeculaLogFormatter(
         fmt_with_rank="%(asctime)s [%(levelname)s]: [rank %(process_rank)s] [%(display_name)s]: %(message)s",
@@ -45,6 +50,7 @@ def init_logging(log_level=logging.INFO, process_rank=None):
     for handler in root.handlers:
         handler.addFilter(SpeculaLogFilter(process_rank))
 
+    logging_initialized = True
 
 class SpeculaLogFilter(logging.Filter):
     '''

--- a/test/test_specula_log.py
+++ b/test/test_specula_log.py
@@ -8,6 +8,7 @@ from specula.log import (
     SpeculaLogAdapter,
     SpeculaLogFormatter,
     INIT_PLACEHOLDER_NAME,
+    reset_logging,
 )
 
 
@@ -17,6 +18,7 @@ class TestSpeculaLogging(unittest.TestCase):
         """Reset logging before each test to avoid global state issues."""
         logging.shutdown()
         importlib.reload(logging)
+        reset_logging()
 
     # ------------------------
     # get_specula_logger


### PR DESCRIPTION
This PR fixes a bug that results in multiple log lines when specula.init() is called multiple times. This happens often in tests.