### PR TITLE
Bugfix

### DIFF
--- a/specula/processing_objects/abstract_coronagraph.py
+++ b/specula/processing_objects/abstract_coronagraph.py
@@ -206,7 +206,7 @@ class Coronagraph(BaseProcessingObj):
             xShiftPhInPixel=0,
             yShiftPhInPixel=0,
             mask_threshold=self.mask_threshold,
-            use_out_ef_cache=True,
+            use_out_ef_cache=False,
             target_device_idx=self.target_device_idx,
             precision=self.precision
         )

--- a/specula/processing_objects/abstract_coronagraph.py
+++ b/specula/processing_objects/abstract_coronagraph.py
@@ -206,7 +206,7 @@ class Coronagraph(BaseProcessingObj):
             xShiftPhInPixel=0,
             yShiftPhInPixel=0,
             mask_threshold=self.mask_threshold,
-            use_out_ef_cache=False,
+            use_out_ef_cache=False,   # Turning this on results in crashes during GPU tests
             target_device_idx=self.target_device_idx,
             precision=self.precision
         )


### PR DESCRIPTION
Disabled EF cache in AbstractCoronograph, because it causes crashes when pytest runs with GPU.
Not sure where the problem is, but I have narrowed it down to line 139:

        self.ef_interpolator.interpolated_ef().ef_at_lambda(self.wavelength_in_nm, out=self.ef_in)

If this line is commented out, there are no crashed anymore even with the EF cache. Although I could not find anything wrong in the actual implementation.