### PR TITLE
Unclear usage of override

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,7 @@
 - Fixed output\_names in PhaseScreenCube
 - Fixed PhaseScreenCube crash on GPU due to np.searchsorted called on a cupy array
 - Fixed start\_time bug in WindowedIntegration
+- Fixed unclear/inconsistent overrides default value and type hint in Simul
 - Optimization of the compute\_ifs\_covmat function
 - ...
 

--- a/specula/simul.py
+++ b/specula/simul.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import inspect
 import itertools

--- a/specula/simul.py
+++ b/specula/simul.py
@@ -32,7 +32,7 @@ class Simul():
     def __init__(self,
                  *param_files,
                  simul_idx=0,
-                 overrides=None,
+                 overrides: str | None = None,
                  stepping=False,
                  diagram=False,
                  diagram_title=None,
@@ -53,7 +53,7 @@ class Simul():
         self.simul_idx = simul_idx
         self.mainParams = None
         if overrides is None:
-            self.overrides = []
+            self.overrides = ""
         else:
             self.overrides = overrides
         self.stepping = stepping


### PR DESCRIPTION
The overrides option is a bit confusing.
https://github.com/ArcetriAdaptiveOptics/SPECULA/blob/b024ca793ba45267a8f401185c39f617d94d01bc/specula/simul.py#L55-L58
looks like overrides needs to be a list, but this leads to failure in the yaml parser. Using a yaml string directly (e.g. `overrides="main.total_time: -1"`) works.

Is this the intended usage? At first glance it looked like a for loop over the overrides is missing here:
https://github.com/ArcetriAdaptiveOptics/SPECULA/blob/b024ca793ba45267a8f401185c39f617d94d01bc/specula/simul.py#L777-L780
