### PR TITLE
(GA) Reject ambiguous '.', '-', ':' characters in object/output names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,7 @@
 - Fixed start\_time bug in WindowedIntegration
 - Optimization of the compute\_ifs\_covmat function
 - Added Fraunhofer far field propagation
+- Fixed silent misparsing/confusing errors in split\_output() when an object, alias or output name contained a reserved '.', '-' or ':' character; added early validation of YAML section names in Simul
 - ...
 
 ## [1.0.3] - 2026-05-18

--- a/specula/connections.py
+++ b/specula/connections.py
@@ -12,29 +12,55 @@ Output = namedtuple('Output', 'obj_name output_key delay ref input_name type')
 def split_output(output_name, use_inputs=False, detect_types=False):
     '''
     Split the output name into object name and output key.
+
+    The expected syntax is (all parts except obj_name.output_key are optional):
+
+        [alias-]obj_name.output_key[:delay]
+
+    ':', '-' and '.' are reserved separator characters: the alias, object
+    name and output key must not contain them, or the string cannot be
+    parsed unambiguously.
     '''
+    original = output_name
+
     if ':' in output_name:
-        output_name, suffix = output_name.split(':')
+        output_name, suffix = output_name.rsplit(':', 1)
         if detect_types:
             if suffix in ['float', 'int', 'str']:
                 delay = 0
                 typ_ = suffix
             else:
-                raise ValueError(f'Unknown type {suffix}')
+                raise ValueError(f"Invalid output specification '{original}': "
+                                  f"suffix after ':' must be one of float/int/str, got '{suffix}'")
         else:
-            delay = int(suffix)
+            try:
+                delay = int(suffix)
+            except ValueError:
+                raise ValueError(f"Invalid output specification '{original}': "
+                                  f"expected an integer delay after ':', got '{suffix}'") from None
             typ_ = None
     else:
         delay = 0
         typ_ = None
 
     if '-' in output_name:
-        input_name, output_name = output_name.split('-')
+        parts = output_name.split('-')
+        if len(parts) != 2:
+            raise ValueError(f"Invalid output specification '{original}': found {len(parts) - 1} "
+                              "'-' character(s), but only one is allowed, to separate an optional "
+                              "alias from 'obj_name.output_key' (alias, object and output names "
+                              "must not contain '-')")
+        input_name, output_name = parts
     else:
         input_name = None
 
     if '.' in output_name:
-        obj_name, output_key = output_name.split('.')
+        parts = output_name.split('.')
+        if len(parts) != 2:
+            raise ValueError(f"Invalid output specification '{original}': found {len(parts) - 1} "
+                              "'.' character(s) in 'obj_name.output_key', but only one is allowed "
+                              "(object and output names must not contain '.')")
+        obj_name, output_key = parts
     else:
         obj_name = output_name
         output_key = None

--- a/specula/simul.py
+++ b/specula/simul.py
@@ -187,6 +187,29 @@ class Simul():
             self.logger.warning(f'the following objects will not be triggered: {params.keys()}')
         return order, order_index
 
+    def validate_section_names(self, params):
+        '''
+        Reject section (object) names that use characters reserved by the
+        output-reference syntax parsed in split_output(): '.', '-' and ':'.
+
+        These characters separate an optional alias, the object name, the
+        output key and an optional delay/type suffix (e.g. "alias-obj.output:1").
+        An object name containing one of them makes output references
+        ambiguous: e.g. an object named "my-control" cannot be distinguished
+        from an alias "my" applied to an object named "control".
+        '''
+        reserved = {
+            '.': "separates 'obj_name' from 'output_key'",
+            '-': "separates an optional alias from 'obj_name.output_key'",
+            ':': "introduces an optional delay/type suffix",
+        }
+        for key in params.keys():
+            for ch, purpose in reserved.items():
+                if ch in key:
+                    raise ValueError(f"Invalid section name '{key}' in parameter file: "
+                                      f"character '{ch}' is reserved ({purpose}) and cannot "
+                                      "be used in object names")
+
     def setSimulParams(self, params):
         for key, pars in params.items():
             classname = pars['class']
@@ -805,6 +828,8 @@ class Simul():
 
         # Actual creation code
         self.apply_overrides(params)
+
+        self.validate_section_names(params)
 
         self.trigger_order, self.trigger_order_idx = self.build_trigger_order(params)
         self.logger.info(f'{self.trigger_order=}')

--- a/test/test_connections.py
+++ b/test/test_connections.py
@@ -8,9 +8,60 @@ from specula import np, cp
 from specula import cpuArray
 
 from specula.base_value import BaseValue
-from specula.connections import InputList, InputValue, _InputItem
+from specula.connections import InputList, InputValue, _InputItem, split_output
 
 from test.specula_testlib import cpu_and_gpu
+
+
+class TestSplitOutput(unittest.TestCase):
+
+    def test_plain(self):
+        output = split_output('control.out_comm')
+        self.assertEqual(output.obj_name, 'control')
+        self.assertEqual(output.output_key, 'out_comm')
+        self.assertIsNone(output.input_name)
+        self.assertEqual(output.delay, 0)
+
+    def test_alias(self):
+        output = split_output('comm-control.out_comm')
+        self.assertEqual(output.obj_name, 'control')
+        self.assertEqual(output.output_key, 'out_comm')
+        self.assertEqual(output.input_name, 'comm')
+
+    def test_alias_with_dot_is_allowed(self):
+        # A dot in the alias (the part used as filename by DataStore/DataBuffer)
+        # does not conflict with the '-' and '.' used as syntax separators,
+        # because the alias is split off (on '-') before the object.output
+        # part is split (on '.').
+        output = split_output('sr.5000-slopec.out_slopes')
+        self.assertEqual(output.input_name, 'sr.5000')
+        self.assertEqual(output.obj_name, 'slopec')
+        self.assertEqual(output.output_key, 'out_slopes')
+
+    def test_delay_suffix(self):
+        output = split_output('control.out_comm:1')
+        self.assertEqual(output.delay, 1)
+
+    def test_object_name_with_dot_raises(self):
+        with self.assertRaises(ValueError):
+            split_output('my.control.out_comm')
+
+    def test_object_name_with_extra_dash_raises(self):
+        with self.assertRaises(ValueError):
+            split_output('comm-my-control.out_comm')
+
+    def test_alias_with_dash_raises(self):
+        with self.assertRaises(ValueError):
+            split_output('my-alias-control.out_comm')
+
+    def test_object_name_with_colon_raises(self):
+        with self.assertRaises(ValueError):
+            split_output('my:control.out_comm')
+
+    def test_invalid_delay_suffix_raises(self):
+        with self.assertRaises(ValueError):
+            split_output('control.out_comm:notanumber')
+
 
 class TestConnections(unittest.TestCase):
    

--- a/test/test_simul.py
+++ b/test/test_simul.py
@@ -259,6 +259,29 @@ class TestSimul(unittest.TestCase):
         assert params['dm'] == original_params['dm']      # Unchanged
         assert 'dm2' not in params
 
+    def test_validate_section_names_accepts_clean_names(self):
+        simul = Simul('dummy.yaml')
+        params = {'main': {}, 'atmo_0': {}, 'dm2': {}}
+        simul.validate_section_names(params)  # Should not raise
+
+    def test_validate_section_names_rejects_dot(self):
+        simul = Simul('dummy.yaml')
+        params = {'my.control': {}}
+        with self.assertRaises(ValueError):
+            simul.validate_section_names(params)
+
+    def test_validate_section_names_rejects_dash(self):
+        simul = Simul('dummy.yaml')
+        params = {'my-control': {}}
+        with self.assertRaises(ValueError):
+            simul.validate_section_names(params)
+
+    def test_validate_section_names_rejects_colon(self):
+        simul = Simul('dummy.yaml')
+        params = {'my:control': {}}
+        with self.assertRaises(ValueError):
+            simul.validate_section_names(params)
+
     def test_unknown_parameter_raises_value_error(self):
         '''Test that a YAML parameter not present in the class constructor raises ValueError'''
         yml = '''


### PR DESCRIPTION
## Summary
- `split_output()` now raises a clear ValueError instead of a cryptic
  unpacking/int() error when an alias, object name, or output key
  contains a reserved separator ('.', '-', ':') in an ambiguous way.
- New `Simul.validate_section_names()` rejects YAML section names
  containing '.', '-', or ':' at parameter-load time, closing a case
  where a single '-' in an object name (e.g. "my-control") was
  silently misparsed as alias "my" on object "control" with no error.
- Added unit tests covering both valid and invalid patterns.
