### PR TITLE
(GA) Fix for a bug relating to toccd_side in ModulatedPyramid

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,7 @@
 - Fixed silent misparsing/confusing errors in split\_output() when an object, alias or output name contained a reserved '.', '-' or ':' character; added early validation of YAML section names in Simul
 - Fixed A size in get_pyr_tlt, adding a round (rather than flooring by default) to avoid cases where the pyramid tilt mask (pyr_tlt) and the focal plane mask (fp_mask) could be of different sizes when using an odd number of pixels across the pupil
 - Updated calculation of power loss such that reference PSF also uses Fresnel propagation
+- Fixed ModulatedPyramid/ModulatedDoubleRoof.calc\_pyr\_geometry producing pupils smaller than the requested pup\_diam pixels whenever pup\_dist was large enough to trigger the fft\_res\_min increase (roughly pup\_dist > 1.73 \* pup\_diam with default pup\_margin): fft\_totsize grew with the bumped fft\_res, but toccd\_side (the internal CCD side the FFT-plane pupils are rebinned to via toccd()) stayed frozen at the value computed from the pre-bump, nominal fft\_res, shrinking the sub-pupils after rebinning. toccd\_side is now recomputed from the final fft\_res returned by calc\_geometry. Added regression test in test\_pyr.py
 
 ## [1.0.3] - 2026-05-18
 

--- a/specula/processing_objects/modulated_pyramid.py
+++ b/specula/processing_objects/modulated_pyramid.py
@@ -368,14 +368,19 @@ class ModulatedPyramid(BaseProcessingObj):
 
         fft_res = result['fft_res']
 
+        # Recompute toccd_side from the final fft_res (not the pre-bump internal_ccd_side
+        # above): otherwise, whenever fft_res_min increased fft_res, the pupils come out
+        # smaller than pup_diam pixels after the toccd() rebin below.
+        toccd_side = int(self.xp.around(fft_res * pup_diam / 2) * 2)
+
         result.update(
             {
             'tilt_scale': fft_res / ((pup_dist / float(pup_diam)) / 2.0),
-            'toccd_side': internal_ccd_side,
+            'toccd_side': toccd_side,
             'final_ccd_side': ccd_side
             }
         )
-        
+
         return result
 
     def get_pyr_tlt(self, p, c):

--- a/test/test_pyr.py
+++ b/test/test_pyr.py
@@ -1062,6 +1062,77 @@ class TestModulatedPyramid(unittest.TestCase):
 
 
     @cpu_and_gpu
+    def test_pup_diam_matches_requested_diameter_for_large_pup_dist(self, target_device_idx, xp):
+        """Regression test for calc_pyr_geometry: toccd_side must be recomputed from the
+        final (possibly fft_res_min-bumped) fft_res, otherwise the sub-pupils shrink
+        below the requested pup_diam pixels once pup_dist is large enough to trigger
+        the fft_res_min constraint (roughly pup_dist > 1.73 * pup_diam with the
+        default pup_margin=2)."""
+
+        pixel_pupil = 160
+        pixel_pitch = 0.05
+        wavelength_in_nm = 750
+        fov = 2.0
+        pup_diam = 20
+        output_resolution = 80
+        mod_amp = 3.0
+
+        simul_params = SimulParams(
+            pixel_pupil=pixel_pupil,
+            pixel_pitch=pixel_pitch,
+        )
+
+        def _pupil_diameters(pup_dist):
+            pyramid = ModulatedPyramid(
+                simul_params=simul_params,
+                wavelengthInNm=wavelength_in_nm,
+                fov=fov,
+                pup_diam=pup_diam,
+                pup_dist=pup_dist,
+                output_resolution=output_resolution,
+                mod_amp=mod_amp,
+                target_device_idx=target_device_idx,
+            )
+
+            ef = ElectricField(
+                pixel_pupil, pixel_pupil, pixel_pitch, S0=100, target_device_idx=target_device_idx
+            )
+            ef.A = make_mask(pixel_pupil)
+            ef.generation_time = 0
+
+            pyramid.inputs['in_ef'].set(ef)
+
+            loop = LoopControl()
+            loop.add(pyramid, idx=0)
+            loop.run(run_time=1, dt=1, t0=0)
+
+            pupcalib = PyrPupdataCalibrator(
+                data_dir="/tmp",
+                target_device_idx=target_device_idx,
+            )
+            pupcalib.local_inputs['in_i'] = pyramid.outputs['out_i']
+            pupcalib.trigger_code()
+            return cpuArray(pupcalib.pupdata.radius) * 2
+
+        # pup_dist=50 triggers the fft_res_min bump: fft_res_min = (50+20)/20*1.1 = 3.85 > 3.0
+        diam_large_dist = _pupil_diameters(pup_dist=50)
+        np.testing.assert_allclose(
+            diam_large_dist, pup_diam, atol=2.0,
+            err_msg=f"Pupil diameters {diam_large_dist} should match requested pup_diam="
+                    f"{pup_diam} even when pup_dist is large enough to bump fft_res"
+        )
+
+        # Sanity check: pup_dist=30 stays below the bump threshold
+        # (fft_res_min = (30+20)/20*1.1 = 2.75 < 3.0) and should also match pup_diam,
+        # both before and after the fix, guarding against regressions in the normal case.
+        diam_small_dist = _pupil_diameters(pup_dist=30)
+        np.testing.assert_allclose(
+            diam_small_dist, pup_diam, atol=2.0,
+            err_msg=f"Pupil diameters {diam_small_dist} should match requested pup_diam="
+                    f"{pup_diam} when pup_dist is below the fft_res_min bump threshold"
+        )
+
+    @cpu_and_gpu
     def test_imperfect_edges(self, target_device_idx, xp):
         
         pixel_pupil = 100


### PR DESCRIPTION
This pull request addresses an issue where the `ModulatedPyramid` and `ModulatedDoubleRoof` classes could produce sub-pupils smaller than the requested `pup_diam` under certain conditions, specifically when `pup_dist` was large enough to trigger an increase in `fft_res_min`. The fix ensures that the internal CCD side (`toccd_side`) is recalculated based on the final, potentially increased `fft_res`, so the output pupils maintain the correct size. A regression test has been added to verify this behavior.

Bug fix to pupil size calculation:

* In `specula/processing_objects/modulated_pyramid.py`, the `calc_pyr_geometry` method now recalculates `toccd_side` using the final `fft_res`, ensuring the output pupils match the requested `pup_diam` even when `fft_res_min` is bumped due to a large `pup_dist`.

Testing and validation:

* Added a regression test `test_pup_diam_matches_requested_diameter_for_large_pup_dist` in `test/test_pyr.py` to confirm that the pupil diameter matches the requested value both when `pup_dist` triggers the `fft_res_min` bump and when it does not.

Documentation:

* Updated `ChangeLog.md` to describe the bug, the fix, and the addition of the regression test for clarity and future reference.