### PR TITLE
Add window_xy for displays and Opticalib IM calib path

### DIFF
--- a/specula/calib_manager.py
+++ b/specula/calib_manager.py
@@ -43,6 +43,7 @@ class CalibManager():
             'intmat': 'im/',
             'Intmat': 'im/',
             'ImCalibrator': 'im/',
+            'OpticalibPushPullImCalibrator': 'im/',
             'MultiImCalibrator': 'im/',
             'projmat': 'rec/',
             'RecCalibrator': 'rec/',

--- a/specula/display/base_display.py
+++ b/specula/display/base_display.py
@@ -19,7 +19,8 @@ class BaseDisplay(BaseProcessingObj):
                  title='',
                  window: int=None,
                  subplot: int=111,
-                 figsize=(8, 6)):
+                 figsize=(8, 6),
+                 window_xy=None):
         super().__init__()
 
         if window is None:
@@ -44,12 +45,35 @@ class BaseDisplay(BaseProcessingObj):
 
         if not self.onNotebook:
             self.fig.show()
+            if window_xy is not None:
+                self._set_window_position(window_xy)
         else:
             from IPython.display import display
             self.handle = display(self.fig, display_id=True)
 
         self.output_id = IntValue(value=-1)
         self.outputs['out_window_id'] = self.output_id
+
+    def _set_window_position(self, window_xy):
+        """Place the GUI window at screen pixel (x, y) if the backend allows it."""
+        try:
+            x, y = int(window_xy[0]), int(window_xy[1])
+        except (TypeError, ValueError, IndexError):
+            return
+        try:
+            manager = self.fig.canvas.manager
+            if hasattr(manager, 'window'):
+                win = manager.window
+                if hasattr(win, 'wm_geometry'):
+                    win.wm_geometry(f'+{x}+{y}')
+                elif hasattr(win, 'move'):
+                    win.move(x, y)
+                elif hasattr(win, 'setGeometry') and hasattr(self.fig, 'dpi'):
+                    w = int(self.figsize[0] * self.fig.dpi)
+                    h = int(self.figsize[1] * self.fig.dpi)
+                    win.setGeometry(x, y, w, h)
+        except Exception as e:
+            self.logger.debug(f'Could not set window position: {e}')
 
     @classmethod
     def output_names(cls):

--- a/specula/display/pixels_display.py
+++ b/specula/display/pixels_display.py
@@ -47,6 +47,7 @@ class PixelsDisplay(BaseDisplay):
                  crop_mode='slice',
                  window: int=None,
                  subplot: int=111,
+                 window_xy=None,
                  ):
 
         super().__init__(
@@ -54,6 +55,7 @@ class PixelsDisplay(BaseDisplay):
             figsize=figsize,
             window=window,
             subplot=subplot,
+            window_xy=window_xy,
         )
         self.img = None
 

--- a/specula/display/pixels_pup_display.py
+++ b/specula/display/pixels_pup_display.py
@@ -56,6 +56,7 @@ class PixelsPupDisplay(BaseDisplay):
         self.circles = []
         self.center_points = []
         self.text_block = None
+        self.img = None
 
 
     def _apply_crop(self, image):

--- a/specula/display/plot_display.py
+++ b/specula/display/plot_display.py
@@ -17,12 +17,14 @@ class PlotDisplay(BaseDisplay):
                  labels=None,
                  window: int=None,
                  subplot: int=111,
+                 window_xy=None,
                  ):
         super().__init__(
             title=title,
             figsize=figsize,
             window=window,
             subplot=subplot,
+            window_xy=window_xy,
         )
 
         self._histlen = histlen

--- a/specula/display/slopec_display.py
+++ b/specula/display/slopec_display.py
@@ -13,12 +13,14 @@ class SlopecDisplay(BaseDisplay):
                  unit='slopes',
                  window: int=None,
                  subplot: int=111,
+                 window_xy=None,
                  ):
         super().__init__(
             title=title,
             figsize=figsize,
             window=window,
             subplot=subplot,
+            window_xy=window_xy,
         )
 
         self.img = None

--- a/specula/processing_objects/dynamic_dark_calibrator.py
+++ b/specula/processing_objects/dynamic_dark_calibrator.py
@@ -71,6 +71,7 @@ class DynamicDarkCalibrator(BaseProcessingObj):
                  data_dir: str,      # Set by main Simul object
                  nframes: int,
                  overwrite: bool = False,
+                 dark_frame_tag: str = None,
                  target_device_idx: int = None,
                  precision: int = None):
         """
@@ -85,6 +86,8 @@ class DynamicDarkCalibrator(BaseProcessingObj):
         overwrite : bool
             If True, overwrite existing files when saving dark frames.
             Default is False.
+        dark_frame_tag : str
+            Tag of the dark frame to load at startup (optional)
         target_device_idx : int [1], optional
             Target device index for computation (e.g., CPU/GPU selection).
         precision : int [1], optional
@@ -123,6 +126,8 @@ class DynamicDarkCalibrator(BaseProcessingObj):
         self.outputs['out_darkframe'] = self.darkframe
         self.outputs['out_subtracted_pixels'] = self.subtracted_pixels
 
+        self.dark_frame_tag = dark_frame_tag
+
     @classmethod
     def input_names(cls):
         return {'in_pixels': InputDesc(Pixels, 'Input pixel frame to be dark-subtracted'),
@@ -153,6 +158,19 @@ class DynamicDarkCalibrator(BaseProcessingObj):
                                       in_pixels.bpp,
                                       in_pixels.signed)
         self.integrated_pixels = self.darkframe.pixels * 0
+
+        if self.dark_frame_tag is not None:
+            filename = self.dark_frame_tag
+            if not filename.endswith('.fits'):
+                filename += '.fits'
+            fullpath = os.path.join(self.data_dir, filename)
+            try:
+                self.darkframe = Pixels.restore(fullpath, target_device_idx=self.target_device_idx)
+                self.darkframe.generation_time = self.current_time
+                self.counter = 0  # Disable integration
+                self.logger.info(f'Loaded dark frame from {fullpath}')
+            except Exception as e:
+                self.logger.error(f'Exception: {e.__name__}: {e}')
 
     def trigger_code(self):
         """Main calibration function"""

--- a/specula/processing_objects/integrator.py
+++ b/specula/processing_objects/integrator.py
@@ -1,4 +1,6 @@
 
+import numpy as np
+
 from specula.processing_objects.iir_filter import IirFilter
 from specula.base_processing_obj import InputDesc, OutputDesc
 from specula.base_value import BaseValue
@@ -27,24 +29,32 @@ class Integrator(IirFilter):
         # - If n_modes is a list, its length must match int_gain.
         # - Each int_gain[i] is expanded into a block of size n_modes[i].
         #   Example: n_modes=[2,3], int_gain=[0.5, 1.0] -> int_gain = [0.5, 0.5, 1.0, 1.0, 1.0]
-        # - If ff is provided, it is expanded in the same way as int_gain.
+        # - If ff is provided:
+        #     * scalar / length-1 -> broadcast to all modes
+        #     * length == len(n_modes) -> expand like int_gain (numpy.repeat)
+        #     * length == sum(n_modes) (or longer) -> per-mode vector (truncate if longer)
         # - Raises ValueError if the lengths do not match.
-        # Note: this behaviour (repeat each element of int_gain and ff by the corresponding
-        #       number in n_modes) is the same as numpy.repeat
         if n_modes is not None:
             if isinstance(n_modes, int):
                 n_modes = [n_modes]
             if len(n_modes) != len(int_gain):
                 raise ValueError(f"When n_modes is a list, length of n_modes {len(n_modes)} must"
                                  f" match length of int_gain {len(int_gain)}")
+            n_total = int(sum(n_modes))
             int_gain = [val for i, val in enumerate(int_gain) for _ in range(n_modes[i])]
             if ff is not None:
-                if isinstance(ff, int):
-                    ff = [ff]
-                if len(n_modes) != len(ff):
-                    raise ValueError(f"When n_modes is a list, length of n_modes {len(n_modes)}"
-                                     f" must match length of ff {len(ff)}")
-                ff = [val for i, val in enumerate(ff) for _ in range(n_modes[i])]
+                ff_arr = np.asarray(ff, dtype=float).ravel()
+                if ff_arr.size == 1:
+                    ff = np.repeat(ff_arr, n_total)
+                elif ff_arr.size == len(n_modes):
+                    ff = np.repeat(ff_arr, n_modes)
+                elif ff_arr.size >= n_total:
+                    ff = ff_arr[:n_total]
+                else:
+                    raise ValueError(
+                        f"ff length {ff_arr.size} incompatible with n_modes "
+                        f"(blocks={len(n_modes)}, total={n_total})"
+                    )
 
         iir_filter_data = IirFilterData.from_gain_and_ff(int_gain, ff=ff,
                                                target_device_idx=target_device_idx)

--- a/specula/processing_objects/specula_input.py
+++ b/specula/processing_objects/specula_input.py
@@ -76,7 +76,7 @@ class SpeculaInput(BaseProcessingObj):
                         self.outputs[name].value = cast_func(value)
                         self.outputs[name].generation_time = self.current_time
                     except Exception as e:
-                        self.logger.error('Rejected input {value} for output {name}: cannot convert to type {cast_func}')
+                        self.logger.error(f'Rejected input {value} for output {name}: cannot convert to type {cast_func}')
                 except KeyError:
                     self.logger.error(f'Unknown output: {name}')
         except queue.Empty:


### PR DESCRIPTION
## Summary
- Add optional `window_xy` to `BaseDisplay` and pass-through on pixels/plot/slopec displays for lab window placement
- Register `OpticalibPushPullImCalibrator` in `CalibManager` under `im/`

## Test plan
- [ ] YAML display with `window_xy: [100, 200]` places the matplotlib window when the backend supports it
- [ ] Invalid/missing `window_xy` does not crash display setup
- [ ] SpecuLab Opticalib IM calibrator resolves data_dir under `im/` when used